### PR TITLE
Create after suicide

### DIFF
--- a/IPs/RSKIP131.md
+++ b/IPs/RSKIP131.md
@@ -1,6 +1,6 @@
 # On creating a contract destroyed on the same block
 
-|RSKIP          |NN           |
+|RSKIP          |131           |
 | :------------ |:-------------|
 |**Title**      |Creating a contract destroyed on the same block |
 |**Created**    |10-JUN-19 |

--- a/IPs/RSKIPNN.md
+++ b/IPs/RSKIPNN.md
@@ -1,0 +1,105 @@
+# Create2
+
+|RSKIP          |125           |
+| :------------ |:-------------|
+|**Title**      |Create2 |
+|**Created**    |29-APR-19 |
+|**Author**     | SMS |
+|**Purpose**    |Sca, Usa |
+|**Layer**      |Core |
+|**Complexity** |1 |
+|**Status**     |Draft |
+
+## Abstract
+
+The purpose of this IP is to implement the CREATE2 opcode, as added to the Ethereum VM in the [EIP 1014](http://eips.ethereum.org/EIPS/eip-1014)
+
+## Motivation
+
+Enables the creation of contracts with deterministic and repeatable addresses. This functionality is required for state channels interacting with a contract that only needs to be created on arbitration (also called counterfactual channels).
+
+## Specification
+
+Adds a new opcode at 0xf5, which takes 4 stack arguments: endowment, memory_start, memory_length, salt. Behaves identically to CREATE, except using `keccak256( 0xff ++ address ++ salt ++ keccak256(init_code))[12:]` instead of the usual sender-and-nonce-hash as the address where the contract is initialized at. 
+
+The `CREATE2` has the same `gas` schema as `CREATE`, but also an extra `hashcost` of `GSHA3WORD * ceil(len(init_code) / 32)`, to account for the hashing that must be performed. The `hashcost` is deducted at the same time as memory-expansion gas and `CreateGas` is deducted: _before_ evaluation of the resulting address and the execution of `init_code`.
+
+- `0xff` is a single byte, 
+- `address` is always `20` bytes, 
+- `salt` is always `32` bytes (a stack item). 
+
+The preimage for the final hashing round is thus always exactly `85` bytes long.
+
+
+## Rationale
+
+#### Address formula
+
+* Ensures that addresses created with this scheme cannot collide with addresses created using the traditional `keccak256(rlp([sender, nonce]))` formula, as `0xff` can only be a starting byte for RLP for data many petabytes long.
+* Ensures that the hash preimage has a fixed size,
+
+#### Gas cost
+
+Since address calculation depends on hashing the `init_code`, it would leave clients open to DoS attacks if executions could repeatedly cause hashing of large pieces of `init_code`, since expansion of memory is paid for only once. This EIP uses the same cost-per-word as the `SHA3` opcode. 
+
+### The `CREATE` behavior change
+
+The original [EIP](http://eips.ethereum.org/EIPS/eip-1014) specified what to do in cases of a hash collision of the new address. Basically, in order to prevent this problem, each new contract created by these opcodes would start with its nonce in one, instead of zero. In addition, when there is a collision there is a check done if the existing contract has either non empty code, or non zero nonce, if one of this checks is true then the contract creation fails as if the init_code program would fail. 
+
+This RSKIP introduces a new behavior for the `CREATE` opcode, because every contract created will start with nonce 1, and fail in the rare case that a contract with the same address was previously created. The behavior is exactly the same than in the Ethereum VM, thus improving compatibility.
+
+
+### Examples
+
+Example 0
+* address `0x0000000000000000000000000000000000000000`
+* salt `0x0000000000000000000000000000000000000000000000000000000000000000`
+* init_code `0x00`
+* gas (assuming no mem expansion): `32006`
+* result: `0x4D1A2e2bB4F88F0250f26Ffff098B0b30B26BF38`
+
+Example 1
+* address `0xdeadbeef00000000000000000000000000000000`
+* salt `0x0000000000000000000000000000000000000000000000000000000000000000`
+* init_code `0x00`
+* gas (assuming no mem expansion): `32006`
+* result: `0xB928f69Bb1D91Cd65274e3c79d8986362984fDA3`
+
+Example 2
+* address `0xdeadbeef00000000000000000000000000000000`
+* salt `0x000000000000000000000000feed000000000000000000000000000000000000`
+* init_code `0x00`
+* gas (assuming no mem expansion): `32006`
+* result: `0xD04116cDd17beBE565EB2422F2497E06cC1C9833`
+
+Example 3
+* address `0x0000000000000000000000000000000000000000`
+* salt `0x0000000000000000000000000000000000000000000000000000000000000000`
+* init_code `0xdeadbeef`
+* gas (assuming no mem expansion): `32006`
+* result: `0x70f2b2914A2a4b783FaEFb75f459A580616Fcb5e`
+
+Example 4
+* address `0x00000000000000000000000000000000deadbeef`
+* salt `0x00000000000000000000000000000000000000000000000000000000cafebabe`
+* init_code `0xdeadbeef`
+* gas (assuming no mem expansion): `32006`
+* result: `0x60f3f640a8508fC6a86d45DF051962668E1e8AC7`
+
+Example 5
+* address `0x00000000000000000000000000000000deadbeef`
+* salt `0x00000000000000000000000000000000000000000000000000000000cafebabe`
+* init_code `0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef`
+* gas (assuming no mem expansion): `32012`
+* result: `0x1d8bfDC5D46DC4f61D6b6115972536eBE6A8854C`
+
+Example 6
+* address `0x0000000000000000000000000000000000000000`
+* salt `0x0000000000000000000000000000000000000000000000000000000000000000`
+* init_code `0x`
+* gas (assuming no mem expansion): `32000`
+* result: `0xE33C0C7F7df4809055C3ebA6c09CFe4BaF1BD9e0`
+
+### Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/IPs/RSKIPNN.md
+++ b/IPs/RSKIPNN.md
@@ -20,7 +20,7 @@ With the introduction of the opcode `CREATE2` exists the possibility that, given
 
 This normally would not be a problem, but, in order to reduce accesses on the Unitrie storage, several cache levels were implemented. With this cache implementation the Unitrie is not touched until all transactions are finished. This would mean that, in our problem, there is in the Unitrie an address with all its code and storage, and in the cache there are two operations, one of deletion of this address and the second creation. 
 
-So, what should happen when we commit these changes? Should we consider the order of the operations? Should we make a special check on the commit phase for this case? It should be noted that this use case is both rare and expensive, given the contract creation that it involves (all called from the same address). 
+So, what should happen when we commit these changes? Should we consider the order of the operations? Should we make a special check on the commit phase for this case? It should be noted that this use case is rare, given the contract creation that it involves (all called from the same address). 
 
 Considering all these questions we thought it was better to not change anything regarding the Unitrie implementation and all its cache levels, and put this logic on the place where the problem first occurs, the *contract creation*.
 
@@ -30,7 +30,7 @@ In order to prevent this problem, a special check had to be implemented on the c
 
 ## Backwards Compatibility
 
-This RSKIP defines the behavior to be included with the `CREATE2` opcode, as specified in [RSKIP125](IPs/RSKIP125.md) . All changes originated from this RSKIP are tied to the RSKIP125 and won't be implemented on its own.
+This RSKIP defines the behavior to be included with the `CREATE2` opcode, as specified in [RSKIP125](IPs/RSKIP125.md). All changes originated from this RSKIP are tied to the RSKIP125 and won't be implemented on its own.
 
 ## Copyright
 

--- a/IPs/RSKIPNN.md
+++ b/IPs/RSKIPNN.md
@@ -1,4 +1,4 @@
-# Creating a contract destroyed on the same block
+# On creating a contract destroyed on the same block
 
 |RSKIP          |NN           |
 | :------------ |:-------------|
@@ -16,7 +16,7 @@ The purpose of this IP is to explain the logic behind the decision made to forbi
 
 ## Motivation
 
-Prevents the creation of a contract with the same address of a contract that was destroyed previously in the same block execution. In order to prevent cache inconsistencies across the different cache levels.  
+With the introduction of the opcode of `CREATE2` now exists the possibility that, given a transaction list to be executed on the same block, there would be a transaction that destroys. This normally would not be a problem, but, in order to reduce modification times on the Unitrie storage, several cache levels were implemented.
 
 ## Specification
 

--- a/IPs/RSKIPNN.md
+++ b/IPs/RSKIPNN.md
@@ -30,7 +30,7 @@ In order to prevent this problem, a special check had to be implemented on the c
 
 ## Backwards Compatibility
 
-This RSKIP defines the behavior to be included with the `CREATE2` opcode, as specified in RSKIP125. All changes originated from this RSKIP are tied to the RSKIP125 and won't be implemented on its own.
+This RSKIP defines the behavior to be included with the `CREATE2` opcode, as specified in [RSKIP125](IPs/RSKIP125.md) . All changes originated from this RSKIP are tied to the RSKIP125 and won't be implemented on its own.
 
 ## Copyright
 

--- a/IPs/RSKIPNN.md
+++ b/IPs/RSKIPNN.md
@@ -12,16 +12,16 @@
 
 ## Abstract
 
-The purpose of this IP is to explain the logic behind the decision made to forbid creating a contract that was destroyed on the same block, and how this was implemented.
+The purpose of this RSKIP is to explain the logic behind the decision made to forbid creating a contract that was destroyed on the same block, and how this was implemented.
 
 ## Motivation
 
-With the introduction of the opcode of `CREATE2` now exists the possibility that, given a transaction list to be executed on the same block, there would be a transaction that destroys. This normally would not be a problem, but, in order to reduce modification times on the Unitrie storage, several cache levels were implemented.
+With the introduction of the opcode of `CREATE2` now exists the possibility that, given a transaction list to be executed on the same block, there would be a transaction that destroys. This normally would not be a problem, but, in order to reduce modification times on the Unitrie storage, several cache levels were implemented. 
 
-## Specification
+## Specification	
 
+In order to prevent this problem, a special check had to be implemented. Basically, we keep track of the deleted accounts on previous transactions in the execution of the block and, on the remote case that a `CREATE2` is invoked with the same parameters than the one deleted, then the execution is reverted, and the result is the zero address. As with any error produced by a contract transaction, all gas is spent. 
 
-
-### Copyright
+## Copyright
 
 Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/IPs/RSKIPNN.md
+++ b/IPs/RSKIPNN.md
@@ -28,7 +28,9 @@ Considering all these questions we thought it was better to not change anything 
 
 In order to prevent this problem, a special check had to be implemented on the contract creation logic. Basically, we keep track of the deleted accounts on previous transactions executed on the block and, on the remote case that a `CREATE2` is invoked with the same parameters than the one deleted, then the execution is reverted, and the result is the zero address. As with any error produced by a contract transaction, all gas is spent. 
 
+## Backwards Compatibility
 
+This RSKIP defines the behavior to be included with the `CREATE2` opcode, as specified in RSKIP125. All changes originated from this RSKIP are tied to the RSKIP125 and won't be implemented on its own.
 
 ## Copyright
 

--- a/IPs/RSKIPNN.md
+++ b/IPs/RSKIPNN.md
@@ -18,7 +18,7 @@ The purpose of this RSKIP is to explain the logic behind the decision made to fo
 
 With the introduction of the opcode `CREATE2` exists the possibility that, given a transaction list to be executed on a block, there would be a transaction that destroys a contract and afterwards another transaction creates a new contract on the same address. 
 
-This normally would not be a problem, but, in order to reduce accesses on the Unitrie storage, several cache levels were implemented. With this cache implementation the Unitrie is not touched until all transactions are finished, this would mean that, in our problem, there is in the Unitrie and address with all its code and storage, and in the cache there are two operations, one of deletion of this address and the second creation. 
+This normally would not be a problem, but, in order to reduce accesses on the Unitrie storage, several cache levels were implemented. With this cache implementation the Unitrie is not touched until all transactions are finished. This would mean that, in our problem, there is in the Unitrie an address with all its code and storage, and in the cache there are two operations, one of deletion of this address and the second creation. 
 
 So, what should happen when we commit these changes? Should we consider the order of the operations? Should we make a special check on the commit phase for this case? It should be noted that this use case is both rare and expensive, given the contract creation that it involves (all called from the same address). 
 

--- a/IPs/RSKIPNN.md
+++ b/IPs/RSKIPNN.md
@@ -1,9 +1,9 @@
-# Create2
+# Creating a contract destroyed on the same block
 
-|RSKIP          |125           |
+|RSKIP          |NN           |
 | :------------ |:-------------|
-|**Title**      |Create2 |
-|**Created**    |29-APR-19 |
+|**Title**      |Creating a contract destroyed on the same block |
+|**Created**    |10-JUN-19 |
 |**Author**     | SMS |
 |**Purpose**    |Sca, Usa |
 |**Layer**      |Core |
@@ -12,93 +12,15 @@
 
 ## Abstract
 
-The purpose of this IP is to implement the CREATE2 opcode, as added to the Ethereum VM in the [EIP 1014](http://eips.ethereum.org/EIPS/eip-1014)
+The purpose of this IP is to explain the logic behind the decision made to forbid creating a contract that was destroyed on the same block, and how this was implemented.
 
 ## Motivation
 
-Enables the creation of contracts with deterministic and repeatable addresses. This functionality is required for state channels interacting with a contract that only needs to be created on arbitration (also called counterfactual channels).
+Prevents the creation of a contract with the same address of a contract that was destroyed previously in the same block execution. In order to prevent cache inconsistencies across the different cache levels.  
 
 ## Specification
 
-Adds a new opcode at 0xf5, which takes 4 stack arguments: endowment, memory_start, memory_length, salt. Behaves identically to CREATE, except using `keccak256( 0xff ++ address ++ salt ++ keccak256(init_code))[12:]` instead of the usual sender-and-nonce-hash as the address where the contract is initialized at. 
 
-The `CREATE2` has the same `gas` schema as `CREATE`, but also an extra `hashcost` of `GSHA3WORD * ceil(len(init_code) / 32)`, to account for the hashing that must be performed. The `hashcost` is deducted at the same time as memory-expansion gas and `CreateGas` is deducted: _before_ evaluation of the resulting address and the execution of `init_code`.
-
-- `0xff` is a single byte, 
-- `address` is always `20` bytes, 
-- `salt` is always `32` bytes (a stack item). 
-
-The preimage for the final hashing round is thus always exactly `85` bytes long.
-
-
-## Rationale
-
-#### Address formula
-
-* Ensures that addresses created with this scheme cannot collide with addresses created using the traditional `keccak256(rlp([sender, nonce]))` formula, as `0xff` can only be a starting byte for RLP for data many petabytes long.
-* Ensures that the hash preimage has a fixed size,
-
-#### Gas cost
-
-Since address calculation depends on hashing the `init_code`, it would leave clients open to DoS attacks if executions could repeatedly cause hashing of large pieces of `init_code`, since expansion of memory is paid for only once. This EIP uses the same cost-per-word as the `SHA3` opcode. 
-
-### The `CREATE` behavior change
-
-The original [EIP](http://eips.ethereum.org/EIPS/eip-1014) specified what to do in cases of a hash collision of the new address. Basically, in order to prevent this problem, each new contract created by these opcodes would start with its nonce in one, instead of zero. In addition, when there is a collision there is a check done if the existing contract has either non empty code, or non zero nonce, if one of this checks is true then the contract creation fails as if the init_code program would fail. 
-
-This RSKIP introduces a new behavior for the `CREATE` opcode, because every contract created will start with nonce 1, and fail in the rare case that a contract with the same address was previously created. The behavior is exactly the same than in the Ethereum VM, thus improving compatibility.
-
-
-### Examples
-
-Example 0
-* address `0x0000000000000000000000000000000000000000`
-* salt `0x0000000000000000000000000000000000000000000000000000000000000000`
-* init_code `0x00`
-* gas (assuming no mem expansion): `32006`
-* result: `0x4D1A2e2bB4F88F0250f26Ffff098B0b30B26BF38`
-
-Example 1
-* address `0xdeadbeef00000000000000000000000000000000`
-* salt `0x0000000000000000000000000000000000000000000000000000000000000000`
-* init_code `0x00`
-* gas (assuming no mem expansion): `32006`
-* result: `0xB928f69Bb1D91Cd65274e3c79d8986362984fDA3`
-
-Example 2
-* address `0xdeadbeef00000000000000000000000000000000`
-* salt `0x000000000000000000000000feed000000000000000000000000000000000000`
-* init_code `0x00`
-* gas (assuming no mem expansion): `32006`
-* result: `0xD04116cDd17beBE565EB2422F2497E06cC1C9833`
-
-Example 3
-* address `0x0000000000000000000000000000000000000000`
-* salt `0x0000000000000000000000000000000000000000000000000000000000000000`
-* init_code `0xdeadbeef`
-* gas (assuming no mem expansion): `32006`
-* result: `0x70f2b2914A2a4b783FaEFb75f459A580616Fcb5e`
-
-Example 4
-* address `0x00000000000000000000000000000000deadbeef`
-* salt `0x00000000000000000000000000000000000000000000000000000000cafebabe`
-* init_code `0xdeadbeef`
-* gas (assuming no mem expansion): `32006`
-* result: `0x60f3f640a8508fC6a86d45DF051962668E1e8AC7`
-
-Example 5
-* address `0x00000000000000000000000000000000deadbeef`
-* salt `0x00000000000000000000000000000000000000000000000000000000cafebabe`
-* init_code `0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef`
-* gas (assuming no mem expansion): `32012`
-* result: `0x1d8bfDC5D46DC4f61D6b6115972536eBE6A8854C`
-
-Example 6
-* address `0x0000000000000000000000000000000000000000`
-* salt `0x0000000000000000000000000000000000000000000000000000000000000000`
-* init_code `0x`
-* gas (assuming no mem expansion): `32000`
-* result: `0xE33C0C7F7df4809055C3ebA6c09CFe4BaF1BD9e0`
 
 ### Copyright
 


### PR DESCRIPTION
This RSKIP explains the decision made on the CREATE2 implementation to address a small corner case in which an address was created, destroyed, and created again on the same transaction