### PR TITLE
Updating excluded RSKIPs list

### DIFF
--- a/IPs/RSKIP187.md
+++ b/IPs/RSKIP187.md
@@ -23,28 +23,29 @@ This RSKIP specifies the changes included in the RSK network upgrade name Iris.
 
 ## Included RSKIPs
 
-- TBD
-
-## Proposed RSKIPs
-
 - [RSKIP 153](https://github.com/rsksmart/RSKIPs/pull/184): Add BLAKE2 compression function `F` precompile
 - RSKIP 169: Rectify EXTCODEHASH implementation
 - [RSKIP 170](https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP170.md): 2WP peg-in transactions to any address
 - [RSKIP 171](https://github.com/rsksmart/RSKIPs/pull/171): Arbitrary-length data return mechanism
-- [RSKIP 172](https://github.com/rsksmart/RSKIPs/pull/172): Subroutines for the VM
 - RSKIP 174: Preserve balance in contract creation
 - [RSKIP 176](https://github.com/rsksmart/RSKIPs/pull/176): Trustless fast BTC bridge
 - [RSKIP 179](https://github.com/rsksmart/RSKIPs/pull/179): BTC-RSK timestamp linking
 - [RSKIP 181](https://github.com/rsksmart/RSKIPs/pull/181): Add 2WP peg-in transactions reject events
 - [RSKIP 185](https://github.com/rsksmart/RSKIPs/pull/185): Add 2WP peg-out transactions events and refund support
 - [RSKIP 186](https://github.com/rsksmart/RSKIPs/pull/186): Preserve RSK PowPeg activation block height
-- [RSKIP 188](https://github.com/rsksmart/RSKIPs/pull/188): Precompile for BLS12-381 curve operations
 - [RSKIP 191](https://github.com/rsksmart/RSKIPs/pull/191): Remove non Ethereum opcodes from virtual machine
 - [RSKIP 201](https://github.com/rsksmart/RSKIPs/pull/201): Time-locked Emergency Multisignature
 
+## Discarded RSKIPs
+
+- [RSKIP 188](https://github.com/rsksmart/RSKIPs/pull/188): Precompile for BLS12-381 curve operations
+- [RSKIP 172](https://github.com/rsksmart/RSKIPs/pull/172): Subroutines for the VM
+
 ## Timeline
 
-* Updated: * 2021-02-01 deadline to accept proposals for Iris
+* 2021-03-12: RSKIPs 172 and 188 have been removed since this VM changes are not being included in upcoming Ethereum hard fork
+* 2021-01-15: Updated deadline: 2021-02-01 deadline to accept proposals for Iris
+* 2020-11-20: RSKIP proposed
 
 ## Copyright
 


### PR DESCRIPTION
Updating excluded list, removing VM additions RSKIPs that are finally not being part of the upcoming Ethereum Berlin hard fork