### PR TITLE
Remove irrelevant statement.

### DIFF
--- a/IPs/RSKIP191.md
+++ b/IPs/RSKIP191.md
@@ -15,7 +15,7 @@
 # **Abstract**
 
 This improvement removes opcodes `DUPN`, `SWAPN`, `TXINDEX`.
-They are not part of official Ethereum specification.
+
 
 
 


### PR DESCRIPTION
RSK removed those codes because they required maintaining a fork of Solidity, which it seems nobody wants to do.