### PR TITLE
Update RSKIP240 following internal audit

### DIFF
--- a/IPs/RSKIP240.md
+++ b/IPs/RSKIP240.md
@@ -35,7 +35,7 @@ Storage rent introduces variable fees for trie access. These fees can help in th
 - reduce the risk of storage spam and gas arbitrage
 - encourage developers and product designers to treat state storage more judiciously - important for long term scalability, sustainability and fairness
 - In the future, rent timestamps can be used for new *cache hierarchy*. Long unused parts of the state (old timestamps) can be stored at the lowest levels of caches or slowest disks. 
-- If required in the future, rent timestamps be used for *state expiration (hibernation)*.
+- If required in the future, rent timestamps can be used for other ways of managing state size growth such as *state expiration (hibernation)*.
 
 ## Specification
 
@@ -76,13 +76,13 @@ Illustrative **approximate** examples of rent
 
 ### Rent Collection: Thresholds and Caps
 
-Rent payments are state dependent and therefore *variable*. The same transaction sent at differnt times may trigger the collection of different amounts of rent, or very likely, none at all. This is because the amount of rent due depends on the previous timestamp. Furthermore, we also restrict the amount of rent collected in a transaction for a single trie node to lie in certain ranges.
+Rent payments are state dependent and therefore *variable*. The same transaction sent at different times may trigger the collection of different amounts of rent, or very likely, none at all. That is because the amount of rent due depends on a node's previous timestamp. Furthermore, in any transaction, we restrict the amount of rent collected (if any) for a single trie node to lie in predetermined ranges.
 
 ### Cap on rent collected for a node
 The amount of rent collected in a transaction for an individual trie node is **capped**. This rent collection for each node gets spread across different transactions. Note that this cap is for each individual trie nodes accessed by the transaction, and there is no rent cap at the level of a transaction itself.
 
 ### Minimum threshold for rent collection
-Updating a node's rent timestamp requires a trie *put* operation. When possible, the amount of rent collected should cover the cost of this put operation. Thus, we should collect rent for a node only if it exceeds some minimum "collection threshold". This threshold can be different beased on whether the transaction is updating the value of a trie node or merely reading it. Since updating the value requires a trie put, we can use a lower threshold for rent collection. The threshold will be higher for collecting rent (and updating the timestamp) for a pure read operation. For simplcity, we propose a common set of thresholds for all types of nodes -- irrespective of their content (account info, storage, or contract code). A common threshold can can be justfied even for contract code, because ihe bytecode is not actually stored in the trie itself. All values (pf trie nodes) that are longer than 32 bytes are stored separately.
+Updating a node's rent timestamp requires a trie *put* operation. When possible, the amount of rent collected should cover the cost of this put operation. Thus, we should collect rent for a node only if it exceeds some minimum "collection threshold". This threshold can be different beased on whether the transaction is updating the value of a trie node or merely reading it. Since updating the value requires a trie put, we can use a lower threshold for rent collection. The threshold will be higher for collecting rent (and updating the timestamp) for a pure read operation. For simplcity, we propose a common set of thresholds for all types of nodes -- irrespective of their content (account info, storage, or contract code). A common threshold can can be justified even for contract code, because the bytecode is not actually stored in the trie itself. All values (of trie nodes) that are longer than 32 bytes are stored separately.
 
 Rent *does not* depend directly on opcodes. The reference to opcodes here is merely for illustration. Some operations such as `CALL` can touch several trie nodes (accounts, code, storage). 
 
@@ -94,11 +94,11 @@ Rent *does not* depend directly on opcodes. The reference to opcodes here is mer
 
 **Note**: "N/A" is not applicable.
 
-It is common for the same trie node to be accessed *multiple times*, in *different ways*, and at *different call depths* within the same transaction. Within a single call frame, the amount of rent collected in a transaction should not depend on the order in which or the number of times a trie node is accessed. Naturally, the order of access does matter at different call depths. During the course of any transaction, the rent for a node will be collected *at most once* (provided it exceeds a threshold). 
+It is common for the same trie node to be accessed *multiple times*, in *different ways*, and at *different call depths* within the same transaction. Within a single call frame, the amount of rent collected in a transaction should not depend on the order in which, or the number of times, a trie node is accessed. Naturally, the order of access does matter at different call depths. During the course of any transaction, the rent for a node will be collected *at most once* (provided it exceeds a threshold). 
 
 **New Nodes**: New nodes (of any type) receive the timestamp of the block they are created in. No advanced rent is collected. If needed (in future) advanced rent payment for new nodes can be incorporated into fixed costs.
 
-**Security and DoS:** To increase the costs of IO-DOS attacks, a fee of 2500 gas is charged as part of "storage rent" for attempting to read data from nodes that *do not exist* in the state trie. Unless the entire state trie fits on RAM, such queries force the client to search on disk.  This IO DoS fee effectively adds 2500 gas to such queries. This is kept low because there are legitimate use cases for trying to read values that may not exist, e.g. checking if an address owns any amount of an ERC20 token.
+**Security and DoS:** To increase the costs of IO-DoS attacks, a fee of 2500 gas is charged as part of "storage rent" for attempting to read data from nodes that *do not exist* in the state trie. Unless the entire state trie fits on RAM, such queries force the client to search on disk.  This IO-DoS fee effectively adds 2500 gas to such queries. This is kept low because there are legitimate use cases for trying to read values that may not exist, e.g. checking if an address owns any amount of an ERC20 token.
 
 **Duration cap:** Some parts of the state trie may remain untouched for long periods of time. Letting rent accumulate forever for unused nodes does not make much sense. Therefore, we place a limit on the amount of time for which rent can accrue. This is set at 3 years. If a node remains untouched for 3 years, then the amount of outstanding rent does not grow any further, it remains capped at that level irrespective of the amount computed based on its timestamp.
 
@@ -130,7 +130,13 @@ Just like regular transaction fees, storage rent is paid from a transaction's `g
 
 Usually, when there is an *unhandled exception* at any call depth, transaction execution stops and all state changes are reverted. Any gas used thus far is not refunded. Since all state changes are reverted there is no question of updating any rent timestaps. Technically, the state of the transaction sender's account does change (due to gas used and nonce), but we do not update the rent timestamp.
 
-Tracking, computing, and updating rent status requires some extra computation. Therefore, even if timestamps are not updated following exceptions or reverts, we collect some rent as compensation for the additional resource use. Therefore, if a transaction (including *internal transactions*) fails for some reason then 25% of the *computed storage rent* is collected as compensation for additional resource use. This can be implemented by maintaing a list of trie nodes that were accessed but the changes were *rolled back* (e.g.  an OOG exception or REVERT).
+Tracking, computing, and updating rent status requires some extra computation. Therefore, even if timestamps are not updated following exceptions or reverts, we collect some rent as compensation for the additional resource use. Therefore, if a transaction (including *internal transactions*) fails for some reason then 25% of the *computed storage rent* is collected as compensation for additional resource use. This can be implemented by maintaing a list of trie nodes that were accessed but the changes were *rolled back* (e.g.  an OOG exception or REVERT). Collecting rent after an "OOG" may sound very odd. But it only makes sense in the special case where an internal call has its own restricted gas limit (less than what is available). Otherwise, if a transaction (internal or external) stops executing because it runs out of gas, then no rent collection can happen at all since the transaction never "reaches" the end (when rent collection happens).
+
+### OOG "because of" rent and updated estimateGas
+
+Users and wallet software often use `estimateGas` to set the `gaslimit`, sometimes with an additional cushion. The `estimateGas` method should return an estimate inclusive of rent payments. Otherwise, transactions may fail with an OOG exception. Since rent is state dependent, it may happen that the actual rent computed (when a transaction is mined) is different from the estimated value. Therefore, users should increase the gasLimit in a conservative manner.
+
+It is possible that some wallet software do not use `estimateGas` for simple transafers of RBTC. TO avoid such transactions from failing, we propose that rent tracking and collection should be *turned off* for simple send transactions. These transactions are characterized (identified) by a combination of `gaslimit` set equal to the base value (e.g. 21,000 gas) and they do not have anything in the `data` field.
 
 ### Avoid multiple collections
 
@@ -138,15 +144,17 @@ Rent for any node should not be collected more than once in a transaction. For e
 
 ## Timing of Rent Collection and Refunds
 
-Rent is to be collected at the end of transaction execution. We propose that this should happen *before* the sender receives credit for any refunds. Regular execution gas is collected on the fly as a transaction is executed. This gas must be sourced from the transaction's gaslimit, since it is compensation for irreversible resource use. Since rent is collected at the end of execution, we do not have to be as stringent. We could potentially use refunds to pay for rent. The main effect of this timing (collecting rent before refunds) is that it may increase the *effective* size of refunds. This is because refunds are restricted to be no more than one half of execution gas. So, if the total gas used increases because of rent payments, then so does the amount that can be refunded. This can serve as a small increase in the incentive to reduce state size.
+Regular execution gas is collected on the fly as a transaction is executed. This gas must be sourced from the transaction's gaslimit, since it is compensation for irreversible resource use. We do not have to be as stringent with rent and the collection can wait until the end of transaction execution. One reason for collecting rent at the end (instead of on the fly) is to avoid introducing breaking changes when handling calls that pass a limited amount of gas. Such calls can break (OOG) if the total amount of execution gas and rent exceeds the gaslimit of the internal transaction. 
+
+Then there is the issue of the timing of rent versus refunds. We propose that rent collection should happen *before* the sender receives credit for any refunds.  We could potentially use refunds to pay for rent. The main effect of this timing (collecting rent before refunds) is that it may increase the *effective* size of refunds. This is because refunds are restricted to be no more than one half of execution gas. So, if the total gas used increases because of rent payments, then so does the amount that can be refunded. This can serve as a small increase in the incentive to reduce state size.
 
 ### Deleted cells and `SELF-DESTRUCT`
 
-There are two ways to remove data from state: by setting storage cells to zero (using `SSTORE`), or via self-destructing contracts. There is nothing else to delte, since ordinary accounts must always be stored in state with their nonce. In the case of  `SELF_DESTRUCT`, all of the deleted contract's storage cells are also deleted. Such deletions of storage cells and contracts reduce state size, and are incentivized via partial refunds.
+There are two ways to remove data from state: by setting storage cells to zero (using `SSTORE`), or via self-destructing contracts. There is nothing else to delete, since ordinary accounts must always be stored in state with their nonce. In the case of  `SELF_DESTRUCT`, all of the deleted contract's storage cells are also deleted. Such deletions of storage cells and contracts reduce state size, and are incentivized via partial refunds.
 
-When a storage cell is set to zero, or a contract is destructed, then rent collection proceeds as normal. We compute the outstanding rent and collect it if it exceeds the threshhold. The amount collected is still subject to the per transaction cap. However, since the node will be removed from the trie, there is no point in updating its timestamp.
+When a storage cell is set to zero, or a contract is destructed, then rent collection proceeds as normal. We compute the outstanding rent and collect it if it exceeds the threshold. The amount collected is still subject to the per transaction cap. However, since the node will be removed from the trie, there is no point in updating its timestamp.
 
-One point to note is that for a self-destructing contract, we do not attempt to compute or collect outstanding rent for all of its (soon to be removed) storage cells. For one, trygint to do so may lower the incentive to clear the state (refund gets reduced or eliminated). Furthermore, for a contract with lots of storage, it may not be worth the effort to scan each of its cells to compute the outstanding rent status before deleting them.
+One point to note is that for a self-destructing contract, we do not attempt to compute or collect outstanding rent for all of its (soon to be removed) storage cells. For one, trying to do so may lower the incentive to clear the state (refund gets reduced or eliminated). Furthermore, for a contract with lots of storage, it may not be worth the effort to scan each of its cells to compute the outstanding rent status before deleting them.
 
 ## Rationale
 
@@ -156,11 +164,11 @@ The specification already explains much of the rationale. Here we include some a
 
 The cost of writing a rent timestamp to the trie is an unavoidable accounting cost of implementing storage rent. Lacking data to perform an accurate cost-benefit analysis, we adopt a heuristic and conservative approach.
 
-The cost of *updating* a value in a storage cell is 5000 gas (`SSTORE`). Meanwhile, a *value-transferring* `CALL` costs 9000 gas, which must cover the cost of *two* account updates (the caller's and callee's). Thus, the cost or re-writing data to state trie is around 4000 or 5000 gas. This is why, for pure reads,  we collect rent only if it is higher than 5000 gas.   
+The cost of *updating* a value in a storage cell is 5000 gas (`SSTORE`). Meanwhile, a *value-transferring* `CALL` costs 9000 gas, which must cover the cost of *two* account updates (the caller's and callee's). Thus, the implicit cost or re-writing data to state trie is around 4000 or 5000 gas. This is why, for pure reads,  we collect rent only if it is higher than 5000 gas.   
 
 ## Backwards Compatibility
 
-As already mentioned, this change needs a hard fork. Since rent is collected at the end of transaction execution, we do not expect any breaking changes. All existing contracts should work as before. However, the amount of gas consumed by transactions will be higher than before, but only if a transaction triggers rent collection. Therefore, users and applications should increase the `gaslimit` from previouly used vales. In most cases, the RPC method to `estimate_gas` will provide reasonable guidance, however, users should add a little extra to account for the fact that rent payments are state dependent. The actual rent collected can be higher or lower than expected depending on when a transacion gets included in a block.   
+As already mentioned, this change needs a hard fork. Since rent is collected at the end of transaction execution, we do not expect any breaking changes. All existing contracts should work as before. However, the amount of gas consumed by transactions will be higher than before, but only if a transaction triggers rent collection. Therefore, users and applications should increase the `gaslimit` from previouly used vales. In most cases, the RPC method to `estimateGas` will provide reasonable guidance, however, users should add a little extra to account for the fact that rent payments are state dependent. The actual rent collected can be higher or lower than expected depending on when a transacion gets included in a block. 
 
 ## Implementations
 


### PR DESCRIPTION
* add new co-author (FJ)
* make thresholds the same for all node types
* change value of DoS penalty
* update examples
* clarify rent for deleted nodes
* clarify no double collection of rent
* explain timing of rent collection vs refunds
* clarify timestamp for internal nodes
* remove sections that are no longer relevant (e.g. breaking changes due
to calls with limited gas)