### PR TITLE
RSKIP 453: Prevent address creation on failed CREATE/CREATE2 operations

### DIFF
--- a/IPs/RSKIP453.md
+++ b/IPs/RSKIP453.md
@@ -1,0 +1,51 @@
+---
+rskip: 453
+title: Enhance Compatibility with Ethereum in Contract Deployment
+description: 
+status: Draft
+purpose:    
+author: AS
+layer: Core
+complexity: 2
+created: 2024/10/09
+---
+# MCOPY instruction
+
+
+|RSKIP          | 453 |
+| :------------ |:-------------|
+|**Title**      |MCOPY instruction|
+|**Created**    |OCT-2024 |
+|**Author**     |AS |
+|**Purpose**    |Usa |
+|**Layer**      |Core |
+|**Complexity** |1 |
+|**Status**     |Draft |
+
+
+## Abstract
+
+This RSKIP proposes aligning Rootstock (RSK) contract deployment behavior with Ethereum by failing contract creation. This change ensures no empty contract accounts are left in the state, mirroring Ethereum's behavior.
+
+## Motivation
+
+RSK currently leaves empty contract accounts in the state when contract creation fails, differing from Ethereum. Aligning with Ethereum will improve compatibility, security, and user experience in the ecosystem.
+
+## Specification
+
+1. **Contract Size Limit Exceeded**:  
+   When deploying contracts via CREATE/CREATE2 opcodes, if the code size exceeds the max limit, the contract creation should fail, and no empty contract account should remain in the state.
+
+2. **Insufficient Gas**:  
+   If gas runs out during contract creation (CREATE/CREATE2), the contract creation should fail, and no empty contract account should be created.
+
+3. **No Gas Refund**:  
+   In both cases (code size or gas limit), all remaining gas should be consumed, with no refunds provided.   
+
+## Backward Compatibility
+
+This change is a hard fork and therefore all full nodes must be updated.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/IPs/RSKIP453.md
+++ b/IPs/RSKIP453.md
@@ -1,6 +1,6 @@
 ---
 rskip: 453
-title: Enhance Compatibility with Ethereum in Contract Deployment
+title: Prevent address creation on failed CREATE/CREATE2 operations
 description: 
 status: Draft
 purpose:    
@@ -9,12 +9,12 @@ layer: Core
 complexity: 2
 created: 2024/10/09
 ---
-# MCOPY instruction
+# Prevent address creation on failed CREATE/CREATE2 operations
 
 
 |RSKIP          | 453 |
 | :------------ |:-------------|
-|**Title**      |MCOPY instruction|
+|**Title**      |Prevent Address Creation on Failed CREATE/CREATE2 Operations|
 |**Created**    |OCT-2024 |
 |**Author**     |AS |
 |**Purpose**    |Usa |

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 438 |[Limit the maximum size of initcode and apply extra gas cost for every 32-byte chunk of initcode](IPs/RSKIP438.md)|16-JUL-24 | FML | Fai | Core | 2 | Draft |
 | 445 |[MCOPY instruction](IPs/RSKIP445.md)| 12-AUG-24 | AE | Usa | Core | 2 | Draft |
 | 446 |[Transient storage opcodes](IPs/RSKIP446.md)| 12-AUG-24 | AE | Usa | Core | 2 | Draft|
+| 453 |[Enhance Compatibility with Ethereum in Contract Deployment](IPs/RSKIP453.md)| 09-OCT-24 | AS | Usa | Core | 1 | Draft|
 
 (*) Under evaluation to be implemented in the next reference client release
 
@@ -245,10 +246,12 @@ You can find an easily browseable version of this information [here](https://ips
 |----------|:--------------------------|:---------------------------------------|
 | AE       | Adrian Eidelman           | adrian@rootstocklabs.com               |
 | AL       | Angel Lopez               |                                        |
+| AS       | Angel Soto                | angel.soto@rootstocklabs.com           |
 | AM       | Ariel Mendelzon           | amendelzon@rootstocklabs.com           |
 | DLL      | Diego López León          |                                        |
 | DM       | Diego Masini              |                                        |
 | FJ       | Federico Jinich           | federico@rootstocklabs.com             |
+| FML      | Frederico M. Leal         | frederico.macielleal@rootstocklabs.com |
 | GM       | Guido Medina              |                                        |
 | IO       | Ilan Olkies               | ilan@rootstocklabs.com                 |
 | JIO      | Jose Ignacio Orlicki      |                                        |
@@ -274,7 +277,6 @@ You can find an easily browseable version of this information [here](https://ips
 | SM       | Shreemoy Mishra           | shreemoy@rootstocklabs.com             |
 | SMS      | Sebastian Matias Sicardi  |                                        |
 | VK       | Volodymyr Kravets         | volodymyr@rootstocklabs.com            |
-| FML      | Frederico M. Leal         | frederico.macielleal@rootstocklabs.com |
 
 
 ## Build locally

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 438 |[Limit the maximum size of initcode and apply extra gas cost for every 32-byte chunk of initcode](IPs/RSKIP438.md)|16-JUL-24 | FML | Fai | Core | 2 | Draft |
 | 445 |[MCOPY instruction](IPs/RSKIP445.md)| 12-AUG-24 | AE | Usa | Core | 2 | Draft |
 | 446 |[Transient storage opcodes](IPs/RSKIP446.md)| 12-AUG-24 | AE | Usa | Core | 2 | Draft|
-| 453 |[Enhance Compatibility with Ethereum in Contract Deployment](IPs/RSKIP453.md)| 09-OCT-24 | AS | Usa | Core | 1 | Draft|
+| 453 |[Prevent address creation on failed CREATE/CREATE2 operations](IPs/RSKIP453.md)| 09-OCT-24 | AS | Usa | Core | 1 | Draft|
 
 (*) Under evaluation to be implemented in the next reference client release
 


### PR DESCRIPTION
Motivation
RSK’s goal is to be compatible with Ethereum’s ecosystem. Currently, RSK handles contract creation differently: it leaves an empty contract account when the code size exceeds the limit or gas runs out. Ethereum fails the creation in such scenarios, improving security and consistency. Aligning this behavior will enhance RSK’s compatibility and reliability.