### PR TITLE
RSKIP559: Fix pegouts ordering

### DIFF
--- a/IPs/RSKIP559.md
+++ b/IPs/RSKIP559.md
@@ -1,0 +1,39 @@
+---
+rskip: 559
+title: Deterministic next pegout selection fix
+description: Intorduce clear solution to select next pegout with enough confirmations
+status: Draft
+purpose: Sec
+author: VZ
+layer: Core
+complexity: 2
+created: 2026-04-16
+---
+
+## Abstract
+
+It was determined that we have almost non deterministic behaviour for output of the function `getNextPegoutWithEnoughConfirmations`.
+We are returning first valid match from collection which ordering is depends on JDK internal implementation.
+This is why we were having issues switching to Java 21.
+
+Such behaviour is very hard to predict and it bins nodes to exact set of JDKs.
+Replicating such behaviour in any other programming language is extremely hard.
+
+Elements ordering algorithm must be clear and easy to understand.
+
+
+## Specification & Rationale
+
+Old ordering rule is barely describable becuase it depends on ordering in 2 HashSets where one is feeded into another.
+
+New ordering just reuse existing `BTC_TX_COMPARATOR` that just use lexicographical bytes ordering of serialized transactions.
+This approach is easy, clean and understandable.
+
+
+## Backwards compatibility
+
+Changes reqires a hardfork that will turn on valid elements ordering.
+After hardfork it will be possible to extract all conflicting outputs of `getNextPegoutWithEnoughConfirmations` and hardcode them in mainnet node configuration.
+After that old ordering code will be removed.
+
+For other types of networks like future testnet v4 etc it will be required to activate this RSKIP from the block one. Testnet 3 will be morelikely dismissed till that time so no need to hardcode any outputs for it.

--- a/IPs/RSKIP559.md
+++ b/IPs/RSKIP559.md
@@ -1,0 +1,66 @@
+---
+rskip: 559
+title: Deterministic next pegout selection fix
+description: Introduce a clear solution for selecting the next pegout with enough confirmations
+status: Draft
+purpose: Sec
+author: VZ
+layer: Core
+complexity: 2
+created: 16-APR-26
+---
+
+# Deterministic next pegout selection fix
+
+## Abstract
+
+It was determined that the output of `getNextPegoutWithEnoughConfirmations` is almost non-deterministic.
+We return the first valid match from a collection whose iteration order depends on the JDK's internal implementation.
+This is why we had issues when switching to Java 21.
+
+Such behavior is very hard to predict and it effectively binds nodes to a specific set of JDK versions.
+Replicating this behavior in any other programming language is extremely hard.
+
+Elements ordering algorithm must be clear and easy to understand.
+
+
+## Specification & Rationale
+
+The old selection rule is barely describable because it depends on the ordering of the elements in the `HashSet`s, where one is fed into another.
+
+The new selection rule utilizes the existing `BTC_TX_COMPARATOR`,
+which uses lexicographical byte ordering of serialized transactions.
+`(input collection of unknown order)->[BTC_TX_COMPARATOR]->find first match`
+
+This approach is easy, clean, and understandable.
+
+Eventually the old selection code and Java 17+ compatibility fixes must be removed.
+
+
+## Backwards compatibility
+
+Changes require a hard fork that turns on deterministic element ordering via `BTC_TX_COMPARATOR`.
+
+After the hard fork, all conflicting historical outputs of `getNextPegoutWithEnoughConfirmations`
+should be extracted and hardcoded into the node.
+This will allow us to completely replace the Java-dependent code.
+
+So the final logic flow for `getNextPegoutWithEnoughConfirmations` will be as follows:
+
+ - call the function to get the hardcoded pegout and return it if it exists
+ - if no pegouts are found, fall back to selecting a new pegout from the collection sorted with `BTC_TX_COMPARATOR`
+
+No logic branching is required - hardcoded pegouts exist only before the hard fork,
+this covers all cases where the new selection logic differs from the historical one.
+
+It is not necessary, but it is plausible, to hardcode all historical outputs for cases where there was more than one entry to select from.
+
+## Testnet v3 additional logic
+
+`PegoutsWaitingForConfirmation` storage is mutable,
+it updates after processing of the output taken from `getNextPegoutWithEnoughConfirmations` is finished.
+On the testnet there are several blocks where the next pegout is requested multiple times per block.
+
+Considering this additional logic is required to search for the hardcoded pegout.
+Also, for historical blocks, a sequence of pegouts should be saved for such cases.
+

--- a/IPs/RSKIP559.md
+++ b/IPs/RSKIP559.md
@@ -14,53 +14,35 @@ created: 16-APR-26
 
 ## Abstract
 
-It was determined that the output of `getNextPegoutWithEnoughConfirmations` is almost non-deterministic.
-We return the first valid match from a collection whose iteration order depends on the JDK's internal implementation.
-This is why we had issues when switching to Java 21.
+`getNextPegoutWithEnoughConfirmations` returns the first match found while iterating a `HashSet`,
+whose iteration order is an internal detail of the JDK. The pegout it selects can therefore differ
+between JDK versions. This RSKIP replaces that rule with an explicit ordering.
 
-Such behavior is very hard to predict and it effectively binds nodes to a specific set of JDK versions.
-Replicating this behavior in any other programming language is extremely hard.
+## Motivation
 
-Elements ordering algorithm must be clear and easy to understand.
+A consensus-relevant selection must not depend on the JDK. The current rule binds nodes to a
+specific set of JDK versions, and it is impractical to reimplement in another language.
 
+## Specification
 
-## Specification & Rationale
+From the activation of this RSKIP, `getNextPegoutWithEnoughConfirmations` returns the entry with
+enough confirmations that is the minimum under `BTC_TX_COMPARATOR`, which orders entries by the
+lexicographical byte order of the serialized btc transaction.
 
-The old selection rule is barely describable because it depends on the ordering of the elements in the `HashSet`s, where one is fed into another.
+## Rationale
 
-The new selection rule utilizes the existing `BTC_TX_COMPARATOR`,
-which uses lexicographical byte ordering of serialized transactions.
-`(input collection of unknown order)->[BTC_TX_COMPARATOR]->find first match`
-
-This approach is easy, clean, and understandable.
-
-Eventually the old selection code and Java 17+ compatibility fixes must be removed.
-
+`BTC_TX_COMPARATOR` already exists, orders any two entries, and depends only on data that is already
+part of consensus. The resulting rule is a single sentence and can be reimplemented anywhere.
 
 ## Backwards compatibility
 
-Changes require a hard fork that turns on deterministic element ordering via `BTC_TX_COMPARATOR`.
+Activation requires a hard fork.
 
-After the hard fork, all conflicting historical outputs of `getNextPegoutWithEnoughConfirmations`
-should be extracted and hardcoded into the node.
-This will allow us to completely replace the Java-dependent code.
+Blocks from before the fork must keep replaying to the same state on any JDK. Every historical call
+that had more than one eligible entry is therefore hardcoded in the node, as a per-network map from
+the hash of the `updateCollections` rsk transaction to the hash of the selected btc transaction.
+Calls with zero or one eligible entry were already deterministic and are not recorded.
 
-So the final logic flow for `getNextPegoutWithEnoughConfirmations` will be as follows:
-
- - call the function to get the hardcoded pegout and return it if it exists
- - if no pegouts are found, fall back to selecting a new pegout from the collection sorted with `BTC_TX_COMPARATOR`
-
-No logic branching is required - hardcoded pegouts exist only before the hard fork,
-this covers all cases where the new selection logic differs from the historical one.
-
-It is not necessary, but it is plausible, to hardcode all historical outputs for cases where there was more than one entry to select from.
-
-## Testnet v3 additional logic
-
-`PegoutsWaitingForConfirmation` storage is mutable,
-it updates after processing of the output taken from `getNextPegoutWithEnoughConfirmations` is finished.
-On the testnet there are several blocks where the next pegout is requested multiple times per block.
-
-Considering this additional logic is required to search for the hardcoded pegout.
-Also, for historical blocks, a sequence of pegouts should be saved for such cases.
-
+Before activation the node looks the call up in that map, and on a miss keeps the original selection.
+The comparator is not used before activation: it would change pre-fork results that are not in the
+map, and so diverge from nodes that have not upgraded yet.

--- a/IPs/RSKIP559.md
+++ b/IPs/RSKIP559.md
@@ -1,22 +1,26 @@
 ---
 rskip: 559
-title: Deterministic next pegout selection fix
-description: Introduce a clear solution for selecting the next pegout with enough confirmations
+title: Deterministic selection of the next pegout to confirm
+description: Introduce a clear rule for selecting the next pegout ready to be confirmed and signed
 status: Draft
-purpose: Sec
-author: VZ
+purpose: Usa
+author: JT
 layer: Core
-complexity: 2
-created: 16-APR-26
+complexity: 1
+created: 01-SEP-26
 ---
 
-# Deterministic next pegout selection fix
+# Deterministic selection of the next pegout to confirm
 
 ## Abstract
 
-`getNextPegoutWithEnoughConfirmations` returns the first match found while iterating a `HashSet`,
-whose iteration order is an internal detail of the JDK. The pegout it selects can therefore differ
-between JDK versions. This RSKIP replaces that rule with an explicit ordering.
+Once a pegout has acquired the required number of confirmations in Rootstock, it is ready to be
+confirmed and signed by the powpeg, and the Bridge picks one of the pegouts waiting for
+confirmations to move forward.
+
+It picks it with `getNextPegoutWithEnoughConfirmations`, which returns the first match found while
+iterating a `HashSet`, whose iteration order is an internal detail of the JDK. The pegout selected
+can therefore differ between JDK versions. This RSKIP replaces that rule with an explicit ordering.
 
 ## Motivation
 

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 551 |[Deprecate RSKIP459](IPs/RSKIP551.md)| 18-MAR-26 | MI | Usa | Core | 1 | Draft |
 | 552 |[Improve Blake2F Input Validation](IPs/RSKIP552.md)| 16-MAR-2026 | FML | Sec | Core | 1 | Draft |
 | 553 |[Network Upgrade: Vetiver](IPs/RSKIP553.md)| 23-MAR-2026 | AE | Usa, Sca, Sec | Core | 2 | Draft |
+| 559 |[Fix waiting pegouts ordering](IPs/RSKIP559.md)| 16-APR-2026 | VZ | Sec | Core | 2 | Draft |
 
 # Author Index
 
@@ -293,6 +294,7 @@ You can find an easily browseable version of this information [here](https://ips
 | SM       | Shreemoy Mishra           | shreemoy@rootstocklabs.com             |
 | SMS      | Sebastian Matias Sicardi  |                                        |
 | VK       | Volodymyr Kravets         |                                        |
+| VZ       | Vladislav Zablotsky       |                                        |
 
 
 ## Build locally

--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 551 |[Deprecate RSKIP459](IPs/RSKIP551.md)| 18-MAR-26 | MI | Usa | Core | 1 | Adopted |
 | 552 |[Improve Blake2F Input Validation](IPs/RSKIP552.md)| 16-MAR-2026 | FML | Sec | Core | 1 | Adopted |
 | 553 |[Network Upgrade: Vetiver](IPs/RSKIP553.md)| 23-MAR-2026 | AE | Usa, Sca, Sec | Core | 2 | Adopted |
+| 559 |[Fix waiting pegouts ordering](IPs/RSKIP559.md)| 16-APR-2026 | VZ | Sec | Core | 2 | Draft |
 
 # Author Index
 
@@ -293,6 +294,7 @@ You can find an easily browseable version of this information [here](https://ips
 | SM       | Shreemoy Mishra           | shreemoy@rootstocklabs.com             |
 | SMS      | Sebastian Matias Sicardi  |                                        |
 | VK       | Volodymyr Kravets         |                                        |
+| VZ       | Vladislav Zablotsky       |                                        |
 
 
 ## Build locally

--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 552 |[Improve Blake2F Input Validation](IPs/RSKIP552.md)| 16-MAR-2026 | FML | Sec | Core | 1 | Adopted |
 | 553 |[Network Upgrade: Vetiver](IPs/RSKIP553.md)| 23-MAR-2026 | AE | Usa, Sca, Sec | Core | 2 | Adopted |
 | 555 |[Introducing the Fork-Aware Consensus module](IPs/RSKIP555.md)| 26-MAY-2026 | DC, SDL | Sec | Core | 2 | Draft |
+| 559 |[Fix waiting pegouts ordering](IPs/RSKIP559.md)| 16-APR-2026 | VZ | Sec | Core | 2 | Draft |
 | 712 |[RSK typed structured data hashing and signing](IPs/RSKIP712.md)| 02-NOV-2020 | JL | ST | UI | 2 | Adopted |
 
 
@@ -304,6 +305,7 @@ You can find an easily browseable version of this information [here](https://ips
 | SM       | Shreemoy Mishra           | shreemoy@rootstocklabs.com             |
 | SMS      | Sebastian Matias Sicardi  |                                        |
 | VK       | Volodymyr Kravets         |                                        |
+| VZ       | Vladislav Zablotsky       |                                        |
 
 
 ## Build locally

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 552 |[Improve Blake2F Input Validation](IPs/RSKIP552.md)| 16-MAR-2026 | FML | Sec | Core | 1 | Adopted |
 | 553 |[Network Upgrade: Vetiver](IPs/RSKIP553.md)| 23-MAR-2026 | AE | Usa, Sca, Sec | Core | 2 | Adopted |
 | 555 |[Introducing the Fork-Aware Consensus module](IPs/RSKIP555.md)| 26-MAY-2026 | DC, SDL | Sec | Core | 2 | Draft |
-| 559 |[Fix waiting pegouts ordering](IPs/RSKIP559.md)| 16-APR-2026 | VZ | Sec | Core | 2 | Draft |
+| 559 |[Deterministic selection of the next pegout to confirm](IPs/RSKIP559.md)| 01-SEP-2026 | JT | Usa | Core | 1 | Draft |
 | 712 |[RSK typed structured data hashing and signing](IPs/RSKIP712.md)| 02-NOV-2020 | JL | ST | UI | 2 | Adopted |
 
 
@@ -305,7 +305,6 @@ You can find an easily browseable version of this information [here](https://ips
 | SM       | Shreemoy Mishra           | shreemoy@rootstocklabs.com             |
 | SMS      | Sebastian Matias Sicardi  |                                        |
 | VK       | Volodymyr Kravets         |                                        |
-| VZ       | Vladislav Zablotsky       |                                        |
 
 
 ## Build locally


### PR DESCRIPTION
This pull request introduces a new RSKIP proposal, RSKIP-559, which aims to make the selection of the next pegout to confirm deterministic and independent of JDK internals. This change is important for consensus safety and cross-platform compatibility. The proposal is added as a draft and is referenced in the main index.

**RSKIP-559: Deterministic pegout selection**

* Added a new RSKIP document, `RSKIP559.md`, specifying a deterministic rule for selecting the next pegout to confirm, using a comparator based on the lexicographical byte order of the serialized BTC transaction (`BTC_TX_COMPARATOR`).
* Documented the motivation for this change, emphasizing consensus safety and language independence, and described the need for a hard fork for activation.
* Outlined backwards compatibility measures, including hardcoding historical selections to ensure replay consistency across JDK versions before activation.

**Documentation updates**

* Added RSKIP-559 to the main `README.md` index of proposals, marking it as a draft.