### PR TITLE
RSKIP-169: set status to Adopted

### DIFF
--- a/IPs/RSKIP169.md
+++ b/IPs/RSKIP169.md
@@ -2,7 +2,7 @@
 rskip: 169
 title: Rectify EXTCODEHASH implementation
 description: 
-status: Draft
+status: Adopted
 purpose: Sca
 author: NPS
 layer: Core
@@ -20,7 +20,7 @@ created: 2020-07
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |2 |
-|**Status**     |Draft |
+|**Status**     |Adopted |
 
 
 # **Abstract**


### PR DESCRIPTION
Align the preamble and header-table status (Draft) with the canonical index (Adopted); the EXTCODEHASH fix is implemented and gated behind ConsensusRule.RSKIP169.