### PR TITLE
RSKIP-5 (Shift Operations): set status to Rejected

### DIFF
--- a/IPs/RSKIP05.md
+++ b/IPs/RSKIP05.md
@@ -2,7 +2,7 @@
 rskip: 5
 title: Shift Operations
 description: The EVM lack shift operations. Although shift operations can be carried on using MUL / DIV, shift operations should be much less expensive.
-status: Accepted
+status: Adopted
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,7 @@ created: 2016-06-22
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |1 |
-|**Status**     |Accepted |
+|**Status**     |Adopted |
 
 # **Abstract**
 

--- a/IPs/RSKIP05.md
+++ b/IPs/RSKIP05.md
@@ -2,7 +2,7 @@
 rskip: 5
 title: Shift Operations
 description: The EVM lack shift operations. Although shift operations can be carried on using MUL / DIV, shift operations should be much less expensive.
-status: Adopted
+status: Rejected
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,7 @@ created: 2016-06-22
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |1 |
-|**Status**     |Adopted |
+|**Status**     |Rejected |
 
 # **Abstract**
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 2        | [Dynamic Contract Dependency](IPs/RSKIP02.md)                                     | 11-JUN-16 | SDL       | Sca      | Core     | 2 | Rejected |
 | 3        | [Parallel Execution using static contract dependencies](IPs/RSKIP03.md)           | 22-JUN-16 | SDL       | Sca      | Core     | 2 | Rejected |
 | 4        | [Parallel Execution using runtime contract dependencies](IPs/RSKIP04.md)          | 22-JUN-16 | SDL       | Sca      | Core     | 2 | Accepted |
-| 5        | [Shift Operations](IPs/RSKIP05.md)                                                | 22-JUN-16 | SDL       | Sca      | Core     | 1 | Adopted |
+| 5        | [Shift Operations](IPs/RSKIP05.md)                                                | 22-JUN-16 | SDL       | Sca      | Core     | 1 | Rejected |
 | 6        | [Block Size Limit](IPs/RSKIP06.md)                                                | 22-JUN-16 | SDL       | Sca      | Core     | 1 | Adopted  |
 | 7        | [Persistent Storage Rent Paid by Code](IPs/RSKIP07.md)                            | 11-JUN-16 | SDL       | Sca      | Core     | 3 | Rejected |
 | 8        | [Verification-less mining](IPs/RSKIP08.md)                                        | 29-SEP-16 | SDL       | Fair     | Core     | 2 | Draft    |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 2        | [Dynamic Contract Dependency](IPs/RSKIP02.md)                                     | 11-JUN-16 | SDL       | Sca      | Core     | 2 | Rejected |
 | 3        | [Parallel Execution using static contract dependencies](IPs/RSKIP03.md)           | 22-JUN-16 | SDL       | Sca      | Core     | 2 | Rejected |
 | 4        | [Parallel Execution using runtime contract dependencies](IPs/RSKIP04.md)          | 22-JUN-16 | SDL       | Sca      | Core     | 2 | Accepted |
-| 5        | [Shift Operations](IPs/RSKIP05.md)                                                | 22-JUN-16 | SDL       | Sca      | Core     | 1 | Rejected |
+| 5        | [Shift Operations](IPs/RSKIP05.md)                                                | 22-JUN-16 | SDL       | Sca      | Core     | 1 | Adopted |
 | 6        | [Block Size Limit](IPs/RSKIP06.md)                                                | 22-JUN-16 | SDL       | Sca      | Core     | 1 | Adopted  |
 | 7        | [Persistent Storage Rent Paid by Code](IPs/RSKIP07.md)                            | 11-JUN-16 | SDL       | Sca      | Core     | 3 | Rejected |
 | 8        | [Verification-less mining](IPs/RSKIP08.md)                                        | 29-SEP-16 | SDL       | Fair     | Core     | 2 | Draft    |


### PR DESCRIPTION
Sets RSKIP-5 (Shift Operations) to Rejected in the file frontmatter and its body header table, matching the README index (the file said Accepted, the index Rejected).

RSKIP-5 was superseded by RSKIP-120: its Specification section is a literal copy of the pre-final EIP-145 draft, including the ROL/ROR rotation opcodes (0x1e/0x1f), which were dropped from the final EIP and never implemented in rskj. What ships in rskj is exactly RSKIP-120's opcode set — SHL/SHR/SAR only, defined in [`OpCodes.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/vm/OpCodes.java) and activation-gated behind RSKIP120 in [`VM.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/vm/VM.java) via [`ConsensusRule.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java). The adoption is credited to RSKIP-120 in #622.