### PR TITLE
RSKIP-18 (Fast Hibernation Wakeup using Trie): set status to Rejected

### DIFF
--- a/IPs/RSKIP18.md
+++ b/IPs/RSKIP18.md
@@ -2,7 +2,7 @@
 rskip: 18
 title: Fast Hibernation Wakeup using Trie
 description: 
-status: Draft
+status: Rejected
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,7 @@ created: 2016-09-28
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |2 |
-|**Status**     |Draft |
+|**Status**     |Rejected |
 
 ## Pre-git revisions
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 15       | [Simplified Reward Manager Smart Contract (REMASC)](IPs/RSKIP15.md)              | 14-NOV-16 | SDL       | Sca      | Core     | 3 | Adopted  |
 | 16       | [Combined State Tree](IPs/RSKIP16.md)                                            | 01-NOV-16 | SDL       | Sca      | Core     | 3 | Draft    |
 | 17       | [Simpler Persistent Storage Rent](IPs/RSKIP17.md)                                | 27-SEP-16 | SDL       | Sca      | Core     | 3 | Rejected |
-| 18       | [Fast Hibernation Wakeup using Trie](IPs/RSKIP18.md)                             | 28-SEP-16 | SDL       | Sca      | Core     | 2 | Draft    |
+| 18       | [Fast Hibernation Wakeup using Trie](IPs/RSKIP18.md)                             | 28-SEP-16 | SDL       | Sca      | Core     | 2 | Rejected |
 | 19       | [RSK Address formats](IPs/RSKIP19.md)                                            | 24-NOV-16 | SDL       | Sca      | Core     | 1 | Draft*   |
 | 20       | [Survive and Ephemeral Memory Spaces](IPs/RSKIP20.md)                            | 25-NOV-16 | SDL       | Sca      | Core     | 2 | Draft    |
 | 21       | [Efficient Persistent Storage Rent](IPs/RSKIP21.md)                              | 02-DIC-16 | SDL       | Sca      | Core     | 2 | Draft*   |


### PR DESCRIPTION
Sets RSKIP-18's status to Rejected in the file frontmatter, its body table and the README index. It depends on RSKIP-17's hibernate/wake mechanism, which was formally Rejected; in rskj the hibernate()/wakeUp() methods are only ever called from test scaffolding, never wired to a WAKEUP opcode or consensus path.