### PR TITLE
RSKIP-31 (Hibernation Compression): set status to Rejected

### DIFF
--- a/IPs/RSKIP31.md
+++ b/IPs/RSKIP31.md
@@ -2,7 +2,7 @@
 rskip: 31
 title: Hibernation Compression
 description: 
-status: Draft
+status: Rejected
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,7 @@ created: 2017-01-01
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |3 |
-|**Status**     |Draft |
+|**Status**     |Rejected |
 
 # **Abstract**
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 28       | [Ephemeral segwit](IPs/RSKIP28.md)                                               | 29-DIC-16 | SDL       | Sca      | Core     | 1 | Draft*   |
 | 29       | [Change in Account creation cost](IPs/RSKIP29.md)                                | 01-JAN-17 | SDL       | Sca      | Core     | 1 | Reject   |
 | 30       | [Code Pagination](IPs/RSKIP30.md)                                                | 01-JAN-17 | SDL       | Sca      | Core     | 2 | Draft    |
-| 31       | [Hibernation Compression](IPs/RSKIP31.md)                                        | 10-JAN-17 | SDL       | Sca      | Core     | 3 | Draft    |
+| 31       | [Hibernation Compression](IPs/RSKIP31.md)                                        | 10-JAN-17 | SDL       | Sca      | Core     | 3 | Rejected |
 | 32       | [Double-Hashed Addresses](IPs/RSKIP32.md)                                        | 10-JAN-17 | SDL       | Sca      | Core     | 2 | Draft*   |
 | 33       | [CODEREPLACE opcode](IPs/RSKIP33.md)                                             | 17-JAN-17 | SDL       | Sec/Usa  | Core     | 2 | Adopted    |
 | 34       | [Contract const DATA Sections](IPs/RSKIP34.md)                                   | 20-JAN-17 | SDL       | Sca      | Core     | 1 | Draft*   |


### PR DESCRIPTION
Sets the recorded status (frontmatter, body table, README index) from Draft to Rejected. The proposal depends on RSKIP-18's hibernation mechanism — hibernate()/isHibernated() are test-only scaffolding in rskj, no HIBERNATE opcode or trie-compression logic exists — and RSKIP-18 itself depends on the Rejected RSKIP-17.