### PR TITLE
RSKIP-27: set status to Withdrawn

### DIFF
--- a/IPs/RSKIP27.md
+++ b/IPs/RSKIP27.md
@@ -2,7 +2,7 @@
 rskip: 27
 title: Highly Efficient Storage Rent
 description: 
-status: Draft
+status: Withdrawn
 purpose: Sca, Fair
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,7 @@ created: 2016-12-29
 |**Purpose**    |Sca/Fair |
 |**Layer**      |Core |
 |**Complexity** |2 |
-|**Status**     |Draft |
+|**Status**     |Withdrawn |
 
 # **Abstract**
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 24       | [New Binary Trie](IPs/RSKIP24.md)                                                | 23-DIC-16 | SDL       | Sca      | Core     | 3 | Adopted  |
 | 25       | [Memory caches](IPs/RSKIP25.md)                                                  | 27-DIC-16 | SDL       | Sca      | Core     | 2 | Draft    |
 | 26       | [DUPN and SWAPN opcodes](IPs/RSKIP26.md)                                         | 27-DIC-16 | SDL       | Sca      | Core     | 1 | Adopted  |
-| 27       | [Highly Efficient Storage Rent](IPs/RSKIP27.md)                                  | 29-DIC-16 | SDL       | Sca/Fair | Core     | 2 | Draft    |
+| 27       | [Highly Efficient Storage Rent](IPs/RSKIP27.md)                                  | 29-DIC-16 | SDL       | Sca/Fair | Core     | 2 | Withdrawn |
 | 28       | [Ephemeral segwit](IPs/RSKIP28.md)                                               | 29-DIC-16 | SDL       | Sca      | Core     | 1 | Draft*   |
 | 29       | [Change in Account creation cost](IPs/RSKIP29.md)                                | 01-JAN-17 | SDL       | Sca      | Core     | 1 | Reject   |
 | 30       | [Code Pagination](IPs/RSKIP30.md)                                                | 01-JAN-17 | SDL       | Sca      | Core     | 2 | Draft    |


### PR DESCRIPTION
Sets RSKIP-27 (Highly Efficient Storage Rent) to **Withdrawn** in the frontmatter, the body status table and the README index.

The storage-rent line was withdrawn by its author: neither this proposal nor its cited successors RSKIP-52/RSKIP-113 ever shipped in rskj.
