### PR TITLE
RSKIP-25 (Memory caches): set status to Withdrawn

### DIFF
--- a/IPs/RSKIP25.md
+++ b/IPs/RSKIP25.md
@@ -2,7 +2,7 @@
 rskip: 25
 title: Memory caches
 description: 
-status: Draft
+status: Withdrawn
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,7 @@ created: 2016-12-27
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |2 |
-|**Status**     |Draft |
+|**Status**     |Withdrawn |
 
 ## Pre-git revisions
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 22       | [Commit to number of Merkle tree elements](IPs/RSKIP22.md)                       | 04-DIC-16 | SDL       | Sca      | Core     | 1 | Draft    |
 | 23       | [Onchain PoUBS](IPs/RSKIP23.md)                                                  | 05-DIC-16 | SDL       | Sca      | Core     | 3 | Draft*   |
 | 24       | [New Binary Trie](IPs/RSKIP24.md)                                                | 23-DIC-16 | SDL       | Sca      | Core     | 3 | Adopted  |
-| 25       | [Memory caches](IPs/RSKIP25.md)                                                  | 27-DIC-16 | SDL       | Sca      | Core     | 2 | Draft    |
+| 25       | [Memory caches](IPs/RSKIP25.md)                                                  | 27-DIC-16 | SDL       | Sca      | Core     | 2 | Withdrawn |
 | 26       | [DUPN and SWAPN opcodes](IPs/RSKIP26.md)                                         | 27-DIC-16 | SDL       | Sca      | Core     | 1 | Adopted  |
 | 27       | [Highly Efficient Storage Rent](IPs/RSKIP27.md)                                  | 29-DIC-16 | SDL       | Sca/Fair | Core     | 2 | Draft    |
 | 28       | [Ephemeral segwit](IPs/RSKIP28.md)                                               | 29-DIC-16 | SDL       | Sca      | Core     | 1 | Draft*   |


### PR DESCRIPTION
Sets RSKIP-25 (Memory caches) to Withdrawn in the file frontmatter, its header table and the README index. The tiered RAM/SSD/HDD gas-cost scheme it proposes (40/400/4000 gas) was never implemented in rskj — its caching (DataSourceWithCache, RocksDbDataSource) is an engineering-level cache, not this consensus-gated incentive model. The call is medium-confidence between Withdrawn and Deferred; if the idea is still alive, Deferred may fit better.