### PR TITLE
RSKIP-36 (Transaction Encapsulation): set status to Withdrawn

### DIFF
--- a/IPs/RSKIP36.md
+++ b/IPs/RSKIP36.md
@@ -2,7 +2,7 @@
 rskip: 36
 title: Transaction Encapsulation
 description: 
-status: Draft
+status: Withdrawn
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,7 @@ created: 2017-02-02
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |2 |
-|**Status**     |Draft |
+|**Status**     |Withdrawn |
 
 # **Abstract**
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 33       | [CODEREPLACE opcode](IPs/RSKIP33.md)                                             | 17-JAN-17 | SDL       | Sec/Usa  | Core     | 2 | Adopted    |
 | 34       | [Contract const DATA Sections](IPs/RSKIP34.md)                                   | 20-JAN-17 | SDL       | Sca      | Core     | 1 | Draft*   |
 | 35       | [Managing BridgeMaster Federation Members](IPs/RSKIP35.md)                       | 02-FEB-17 | SDL       | Sca      | Core     | 3 | Draft    |
-| 36       | [Transaction Encapsulation](IPs/RSKIP36.md)                                      | 02-FEB-17 | SDL       | Sca      | Core     | 2 | Draft    |
+| 36       | [Transaction Encapsulation](IPs/RSKIP36.md)                                      | 02-FEB-17 | SDL       | Sca      | Core     | 2 | Withdrawn |
 | 37       | [Single Address Smart Wallets](IPs/RSKIP37.md)                                   | 18-FEB-17 | SDL       | Sca/Usa  | Core     | 3 | Draft    |
 | 38       | [Signature Compression](IPs/RSKIP38.md)                                          | 21-FEB-17 | SDL       | Sca      | Core     | 3 | Draft    |
 | 39       | [Multi-key Accounts](IPs/RSKIP39.md)                                             | 25-FEB-17 | SDL       | Sca      | Core     | 2 | Draft    |


### PR DESCRIPTION
Sets the recorded status (frontmatter, body table, README index — all said Draft) to Withdrawn. rskj carries no trace of the proposed EXECUTE opcode or the account-based third-party fee-payment mechanism, and the 2017 proposal has seen no activity since. Withdrawn was preferred over Deferred on that basis — if the idea is still alive, Deferred works too; happy to adjust.