### PR TITLE
RSKIP-29 (Change in Account creation cost to prevent Spam): set status to Rejected

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 26       | [DUPN and SWAPN opcodes](IPs/RSKIP26.md)                                         | 27-DIC-16 | SDL       | Sca      | Core     | 1 | Adopted  |
 | 27       | [Highly Efficient Storage Rent](IPs/RSKIP27.md)                                  | 29-DIC-16 | SDL       | Sca/Fair | Core     | 2 | Draft    |
 | 28       | [Ephemeral segwit](IPs/RSKIP28.md)                                               | 29-DIC-16 | SDL       | Sca      | Core     | 1 | Draft*   |
-| 29       | [Change in Account creation cost](IPs/RSKIP29.md)                                | 01-JAN-17 | SDL       | Sca      | Core     | 1 | Reject   |
+| 29       | [Change in Account creation cost to prevent Spam](IPs/RSKIP29.md)                | 01-JAN-17 | SDL       | Sca      | Core     | 1 | Rejected |
 | 30       | [Code Pagination](IPs/RSKIP30.md)                                                | 01-JAN-17 | SDL       | Sca      | Core     | 2 | Draft    |
 | 31       | [Hibernation Compression](IPs/RSKIP31.md)                                        | 10-JAN-17 | SDL       | Sca      | Core     | 3 | Draft    |
 | 32       | [Double-Hashed Addresses](IPs/RSKIP32.md)                                        | 10-JAN-17 | SDL       | Sca      | Core     | 2 | Draft*   |


### PR DESCRIPTION
Aligns the README index row with the spec: the RSKIP-29 file explicitly carries status Rejected (and no account-creation-cost change tied to this proposal exists in rskj), while the index still said Reject. Also matches the index title to the file's full title, 'Change in Account creation cost to prevent Spam'.