### PR TITLE
RSKIP-34 (Contract const DATA Sections): set status to Deferred

### DIFF
--- a/IPs/RSKIP34.md
+++ b/IPs/RSKIP34.md
@@ -2,7 +2,7 @@
 rskip: 34
 title: Contract const DATA Sections
 description: 
-status: Draft
+status: Deferred
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,7 @@ created: 2017-01-20
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |1 |
-|**Status**     |Draft |
+|**Status**     |Deferred |
 
 # **Abstract**
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 31       | [Hibernation Compression](IPs/RSKIP31.md)                                        | 10-JAN-17 | SDL       | Sca      | Core     | 3 | Draft    |
 | 32       | [Double-Hashed Addresses](IPs/RSKIP32.md)                                        | 10-JAN-17 | SDL       | Sca      | Core     | 2 | Draft*   |
 | 33       | [CODEREPLACE opcode](IPs/RSKIP33.md)                                             | 17-JAN-17 | SDL       | Sec/Usa  | Core     | 2 | Adopted    |
-| 34       | [Contract const DATA Sections](IPs/RSKIP34.md)                                   | 20-JAN-17 | SDL       | Sca      | Core     | 1 | Draft*   |
+| 34       | [Contract const DATA Sections](IPs/RSKIP34.md)                                   | 20-JAN-17 | SDL       | Sca      | Core     | 1 | Deferred |
 | 35       | [Managing BridgeMaster Federation Members](IPs/RSKIP35.md)                       | 02-FEB-17 | SDL       | Sca      | Core     | 3 | Draft    |
 | 36       | [Transaction Encapsulation](IPs/RSKIP36.md)                                      | 02-FEB-17 | SDL       | Sca      | Core     | 2 | Draft    |
 | 37       | [Single Address Smart Wallets](IPs/RSKIP37.md)                                   | 18-FEB-17 | SDL       | Sca/Usa  | Core     | 3 | Draft    |


### PR DESCRIPTION
Set RSKIP-34 (Contract const DATA Sections) to Deferred in the frontmatter, the header table and the README index (previously Draft / Draft*). Const DATA sections were never implemented in rskj — there is no trace of them in rskj-core — and the 2017 proposal is not under consideration for adoption, which is this repo's definition of Deferred.