### PR TITLE
RSKIP-28: set status to Withdrawn

### DIFF
--- a/IPs/RSKIP28.md
+++ b/IPs/RSKIP28.md
@@ -2,7 +2,7 @@
 rskip: 28
 title: Ephemeral Data
 description: 
-status: Draft
+status: Withdrawn
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,7 @@ created: 2016-12-29
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |1 |
-|**Status**     |Draft |
+|**Status**     |Withdrawn |
 
 [comment]: <> ([ MUST BE COMPLETED WITH THE DESIGN PRESENTED IN THE MIT ])
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 25       | [Memory caches](IPs/RSKIP25.md)                                                  | 27-DIC-16 | SDL       | Sca      | Core     | 2 | Draft    |
 | 26       | [DUPN and SWAPN opcodes](IPs/RSKIP26.md)                                         | 27-DIC-16 | SDL       | Sca      | Core     | 1 | Adopted  |
 | 27       | [Highly Efficient Storage Rent](IPs/RSKIP27.md)                                  | 29-DIC-16 | SDL       | Sca/Fair | Core     | 2 | Draft    |
-| 28       | [Ephemeral segwit](IPs/RSKIP28.md)                                               | 29-DIC-16 | SDL       | Sca      | Core     | 1 | Draft*   |
+| 28       | [Ephemeral Data](IPs/RSKIP28.md)                                                 | 29-DIC-16 | SDL       | Sca      | Core     | 1 | Withdrawn |
 | 29       | [Change in Account creation cost](IPs/RSKIP29.md)                                | 01-JAN-17 | SDL       | Sca      | Core     | 1 | Reject   |
 | 30       | [Code Pagination](IPs/RSKIP30.md)                                                | 01-JAN-17 | SDL       | Sca      | Core     | 2 | Draft    |
 | 31       | [Hibernation Compression](IPs/RSKIP31.md)                                        | 10-JAN-17 | SDL       | Sca      | Core     | 3 | Draft    |


### PR DESCRIPTION
Sets RSKIP-28 (Ephemeral Data) to **Withdrawn** in the frontmatter, the body status table and the README index, and aligns the index title with the spec's own title — the index read `Ephemeral segwit`, the file reads `Ephemeral Data`.

Withdrawn by its author: no progress since 2016 and no implementation in rskj.
