### PR TITLE
RSKIP-0: set status to Adopted

### DIFF
--- a/IPs/RSKIP0.md
+++ b/IPs/RSKIP0.md
@@ -2,7 +2,7 @@
 rskip: 0
 title: RSKIP Purpose and Guidelines
 description: A RSKIP is a design document providing information to the RSK community describing a new feature for RSK, its processes, or its environment.
-status: Purpose and Guidelines
+status: Adopted
 purpose: Sec
 author: JL (@julianlen)
 layer: Misc
@@ -20,7 +20,7 @@ created: 2021-04-15
 |**Purpose**    |Sec |
 |**Layer**      |Misc |
 |**Complexity** |2 |
-|**Status**     |Active |
+|**Status**     |Adopted |
 
 ## What is a RSKIP?
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,13 @@ You can find an easily browseable version of this information [here](https://ips
 
 ## RSKIP status terms
 * **Draft** - an RSKIP that is open for consideration
+* **Active** - an RSKIP whose implementation is completed and accepted by the community, when no hard or soft fork is required.
 * **Accepted** - an RSKIP planned for immediate adoption in the reference client, i.e., expected to be included in the following reference client release.
 * **Adopted** - an RSKIP adopted in a previous reference client release.
 * **Deferred** - an RSKIP not being considered for immediate adoption in the reference client. May be reconsidered in the future for a subsequent release of the reference client.
 * **Rejected** - an RSKIP that was rejected
+* **Withdrawn** - an RSKIP withdrawn by its author(s).
+* **Superseded** - an RSKIP rendered obsolete by a later RSKIP.
 
 ## RSKIP purpose terms
 * **Sca** - an RSKIP that improves scalability


### PR DESCRIPTION
RSKIP-0 is the live governing document for the RSKIP process, but its own status fields disagreed: frontmatter read 'Purpose and Guidelines' and the body table read 'Active'. Both are set to Adopted, matching the README index. The README's 'RSKIP status terms' list is also completed to the full vocabulary RSKIP-0 itself defines (it was missing Active, Withdrawn and Superseded).