### PR TITLE
RSKIP-712: set status to Adopted

### DIFF
--- a/IPs/RSKIP712.md
+++ b/IPs/RSKIP712.md
@@ -2,7 +2,7 @@
 rskip: 712
 title: RSK typed structured data hashing and signing
 description: 
-status: Draft
+status: Adopted
 purpose: ST
 author: JL (@julianlen)
 layer: UI
@@ -20,7 +20,7 @@ created: 2020-11-02
 |**Purpose**    |ST |
 |**Layer**      |UI |
 |**Complexity** |2 |
-|**Status**     |Draft |
+|**Status**     |Adopted |
 
 
-The following RSKIP is a proxy for [EIP712](https://eips.ethereum.org/EIPS/eip-712)
+The following RSKIP is a proxy for [EIP712](https://eips.ethereum.org/EIPS/eip-712). RSK supports EIP-712 typed structured data hashing and signing: as a UI-layer standard it is implemented by wallets and tooling, where it is widely adopted.

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 552 |[Improve Blake2F Input Validation](IPs/RSKIP552.md)| 16-MAR-2026 | FML | Sec | Core | 1 | Adopted |
 | 553 |[Network Upgrade: Vetiver](IPs/RSKIP553.md)| 23-MAR-2026 | AE | Usa, Sca, Sec | Core | 2 | Adopted |
 | 555 |[Introducing the Fork-Aware Consensus module](IPs/RSKIP555.md)| 26-MAY-2026 | DC, SDL | Sec | Core | 2 | Draft |
+| 712 |[RSK typed structured data hashing and signing](IPs/RSKIP712.md)| 02-NOV-2020 | JL | ST | UI | 2 | Adopted |
 
 
 # Author Index


### PR DESCRIPTION
Sets RSKIP-712 to Adopted in the frontmatter and body table, adds its missing row to the README index, and notes in the content that RSK supports EIP-712. It is a UI-layer proxy for EIP-712, which is implemented wallet/tooling-side on RSK and widely adopted there — so node-code absence doesn't argue against it.