### PR TITLE
RSKIP-35 (Managing BridgeMaster Federation Members): set status to Withdrawn

### DIFF
--- a/IPs/RSKIP35.md
+++ b/IPs/RSKIP35.md
@@ -2,7 +2,7 @@
 rskip: 35
 title: Managing BridgeMaster Federation Members
 description: 
-status: Draft
+status: Withdrawn
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,7 @@ created: 2017-02-02
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |3 |
-|**Status**     |Draft |
+|**Status**     |Withdrawn |
 
 # **Abstract**
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 32       | [Double-Hashed Addresses](IPs/RSKIP32.md)                                        | 10-JAN-17 | SDL       | Sca      | Core     | 2 | Draft*   |
 | 33       | [CODEREPLACE opcode](IPs/RSKIP33.md)                                             | 17-JAN-17 | SDL       | Sec/Usa  | Core     | 2 | Adopted    |
 | 34       | [Contract const DATA Sections](IPs/RSKIP34.md)                                   | 20-JAN-17 | SDL       | Sca      | Core     | 1 | Draft*   |
-| 35       | [Managing BridgeMaster Federation Members](IPs/RSKIP35.md)                       | 02-FEB-17 | SDL       | Sca      | Core     | 3 | Draft    |
+| 35       | [Managing BridgeMaster Federation Members](IPs/RSKIP35.md)                       | 02-FEB-17 | SDL       | Sca      | Core     | 3 | Withdrawn |
 | 36       | [Transaction Encapsulation](IPs/RSKIP36.md)                                      | 02-FEB-17 | SDL       | Sca      | Core     | 2 | Draft    |
 | 37       | [Single Address Smart Wallets](IPs/RSKIP37.md)                                   | 18-FEB-17 | SDL       | Sca/Usa  | Core     | 3 | Draft    |
 | 38       | [Signature Compression](IPs/RSKIP38.md)                                          | 21-FEB-17 | SDL       | Sca      | Core     | 3 | Draft    |


### PR DESCRIPTION
Sets the status to Withdrawn in the frontmatter, the body table and the README index (all read Draft). The three-contract BridgeFedFront/BridgeFed/BridgeMaster design was never implemented: rskj's federation management is the vote-based mechanism (voteFederationChange with create/add/commit/rollback in the Bridge precompile), a different design that superseded this 2017 proposal. Confidence in the call is medium — if the idea is still alive, Deferred may fit better; your call as author.