### PR TITLE
RSKIP-38: set status to Withdrawn

### DIFF
--- a/IPs/RSKIP38.md
+++ b/IPs/RSKIP38.md
@@ -2,7 +2,7 @@
 rskip: 38
 title: Signature Compression
 description: 
-status: Draft
+status: Withdrawn
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,7 @@ created: 2017-02-21
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |3 |
-|**Status**     |Draft | 
+|**Status**     |Withdrawn | 
 
 
 # **Abstract**

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 35       | [Managing BridgeMaster Federation Members](IPs/RSKIP35.md)                       | 02-FEB-17 | SDL       | Sca      | Core     | 3 | Draft    |
 | 36       | [Transaction Encapsulation](IPs/RSKIP36.md)                                      | 02-FEB-17 | SDL       | Sca      | Core     | 2 | Draft    |
 | 37       | [Single Address Smart Wallets](IPs/RSKIP37.md)                                   | 18-FEB-17 | SDL       | Sca/Usa  | Core     | 3 | Draft    |
-| 38       | [Signature Compression](IPs/RSKIP38.md)                                          | 21-FEB-17 | SDL       | Sca      | Core     | 3 | Draft    |
+| 38       | [Signature Compression](IPs/RSKIP38.md)                                          | 21-FEB-17 | SDL       | Sca      | Core     | 3 | Withdrawn |
 | 39       | [Multi-key Accounts](IPs/RSKIP39.md)                                             | 25-FEB-17 | SDL       | Sca      | Core     | 2 | Draft    |
 | 40       | [Basic Bridge for two-way-peg to Bitcoin](IPs/RSKIP40.md)                        | 25-APR-17 | SDL       | Usa      | Core     | 2 | Adopted  |
 | 41       | [Extended Bitcoin Bridge Transactions](IPs/RSKIP41.md)                           | 25-APR-17 | SDL       | Usa      | Core     | 2 | Draft*   |


### PR DESCRIPTION
Aligns the frontmatter, body table and README index status to Withdrawn. The spec itself states it is superseded by the Lumino Transaction Compression Protocol (RSKIP-53), and rskj-core carries no signature-aggregation implementation of it.