### PR TITLE
RSKIP-50 (Script Versions using HEADER pseudo-opcode): align index title with the spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 47       | [CALLNUM opcode](IPs/RSKIP47.md)                                                 | 18-OCT-17 | SDL       | Sca      | Core     | 1 | Draft    |
 | 48       | [Informing average free gas per block](IPs/RSKIP48.md)                           | 28-NOV-17 | SDL       | Sca      | Core     | 2 | Draft    |
 | 49       | [One-To-Many hub payment channels](IPs/RSKIP49.md)                               | 01-DIC-17 | SDL       | Sca      | Core     | 2 | Draft    |
-| 50       | [Script Versions using HEADER pesuo-opcode](IPs/RSKIP50.md)                      | 07-DIC-17 | SDL       | Sca      | Core     | 1 | Adopted  |
+| 50       | [Script Versions using HEADER pseudo-opcode](IPs/RSKIP50.md)                     | 07-DIC-17 | SDL       | Sca      | Core     | 1 | Adopted  |
 | 51       | [Memory-Mapped configuration register](IPs/RSKIP51.md)                           | 10-DIC-17 | SDL       | Usa      | Core     | 1 | Adopted  |
 | 52       | [Cache Oriented Storage Rent](IPs/RSKIP52.md)                                    | 12-DIC-17 | SDL       | Sca      | Core     | 2 | Draft*   |
 | 53       | [Lumino Transaction Compression (LTCP)](IPs/RSKIP53.md)                          | 20-FEB-17 | SDL       | Sca      | Core     | 3 | Draft*   |


### PR DESCRIPTION
Fixes the README index title for RSKIP-50: 'pesuo-opcode' → 'pseudo-opcode', matching the RSKIP file's frontmatter, heading, and body table, which all read 'pseudo-opcode'. Statuses already agree everywhere (Adopted), so this is the only change.