### PR TITLE
RSKIP-57: set status to Adopted

### DIFF
--- a/IPs/RSKIP57.md
+++ b/IPs/RSKIP57.md
@@ -2,7 +2,7 @@
 rskip: 57
 title: Derivation Path for Hierarchical Deterministic Wallets
 description: 
-status: Draft
+status: Adopted
 purpose: Usa
 author: IO (@ilan)
 layer: Net
@@ -20,7 +20,7 @@ created: 2018-04-05
 |**Purpose**    |Usa |
 |**Layer**      |Net |
 |**Complexity** |1 |
-|**Status**     |Draft |
+|**Status**     |Adopted |
 
 # **Abstract**
 

--- a/IPs/RSKIP57.md
+++ b/IPs/RSKIP57.md
@@ -51,6 +51,12 @@ Wallets implementing RSK support must use the following derivation path:
 |RSK MainNet|m / 44' / 137' / 0' / 0 / N|
 |RSK TestNet|m / 44' / 37310' / 0' / 0 / N|
 
+## References
+
+| Reference | Description |
+| - | - |
+| [trezor/trezor-common#133](https://github.com/trezor/trezor-common/pull/133) | RSK mainnet/testnet SLIP-44 IDs added to Trezor's coin registry |
+
 ## History
 [BIP-0032](https://www.github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) describes hierarchical deterministic wallets (or "HD Wallets"): wallets which can be shared partially or entirely with different systems, each with or without the ability to spend coins. The specification consists of two parts. In a first part, a system for deriving a tree of keypairs from a single seed is presented. The second part demonstrates how to build a wallet structure on top of such a tree.
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 54       | [Transaction amount & destination privacy](IPs/RSKIP54.md)                       | 07-MAR-17 | SDL       | Usa      | Core     | 3 | Draft    |
 | 55       | [Native Probabilistic payments](IPs/RSKIP55.md)                                  | 11-MAR-17 | SDL       | Usa      | Core     | 3 | Draft*   |
 | 56       | [Sporadic Verification-less mining](IPs/RSKIP56.md)                                  | 11-MAR-17 | SDL       | Fair      | Core     | 3 | Draft   |
-| 57       | [Derivation Path for Hierarchical Deterministic Wallets](IPs/RSKIP57.md)         | 05-ABR-18 | IO | Usa    | Net      | 1 | Draft    |
+| 57       | [Derivation Path for Hierarchical Deterministic Wallets](IPs/RSKIP57.md)         | 05-ABR-18 | IO | Usa    | Net      | 1 | Adopted  |
 | 58       | [Handling Bitcoin Forks](IPs/RSKIP58.md)         | 14-NOV-17 | SDL | Sca    | Core      | 3 | Draft    |
 | 59       | [Child Contracts](IPs/RSKIP59.md)                                                | 11-JUN-16 | SDL       | Sca      | Core     | 1 | Accepted   |
 | 60       | [Checksum Address Encoding](IPs/RSKIP60.md)                                      | 25-JUN-18 | IO | ST     | Net      | 1 | Adopted   |


### PR DESCRIPTION
Sets RSKIP-57's status to Adopted in the file frontmatter, its body table and the README index — all three read Draft. The BIP-44 derivation path it defines (m/44'/137' mainnet, m/44'/37310' testnet) is a wallet-client concern — no node-side implementation was ever expected — and it is adopted in the ecosystem's registries and wallets.

Reference implementations:

| Reference | What it shows |
| --- | --- |
| [SLIP-0044 registry](https://github.com/satoshilabs/slips/blob/master/slip-0044.md) | Coin type 137 registered as RBTC (Rootstock) |
| [trezor/trezor-common#133](https://github.com/trezor/trezor-common/pull/133) | RSK mainnet/testnet SLIP-44 IDs added to Trezor's coin registry (merged Jun 2018, enabling RSKIP-60 checksummed addresses) |