### PR TITLE
RSKIP-55 (Native On-Chain Probabilistic payments): set status to Rejected

### DIFF
--- a/IPs/RSKIP55.md
+++ b/IPs/RSKIP55.md
@@ -2,7 +2,7 @@
 rskip: 55
 title: Native On-Chain Probabilistic payments
 description: 
-status: Draft
+status: Rejected
 purpose: Usa
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,7 @@ created: 2017-03-11
 |**Purpose**    |Usa |
 |**Layer**      |Core |
 |**Complexity** |3 |
-|**Status**     |Draft |
+|**Status**     |Rejected |
 
 # **Abstract**
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 52       | [Cache Oriented Storage Rent](IPs/RSKIP52.md)                                    | 12-DIC-17 | SDL       | Sca      | Core     | 2 | Draft*   |
 | 53       | [Lumino Transaction Compression (LTCP)](IPs/RSKIP53.md)                          | 20-FEB-17 | SDL       | Sca      | Core     | 3 | Draft*   |
 | 54       | [Transaction amount & destination privacy](IPs/RSKIP54.md)                       | 07-MAR-17 | SDL       | Usa      | Core     | 3 | Draft    |
-| 55       | [Native Probabilistic payments](IPs/RSKIP55.md)                                  | 11-MAR-17 | SDL       | Usa      | Core     | 3 | Draft*   |
+| 55       | [Native On-Chain Probabilistic payments](IPs/RSKIP55.md)                         | 11-MAR-17 | SDL       | Usa      | Core     | 3 | Rejected |
 | 56       | [Sporadic Verification-less mining](IPs/RSKIP56.md)                                  | 11-MAR-17 | SDL       | Fair      | Core     | 3 | Draft   |
 | 57       | [Derivation Path for Hierarchical Deterministic Wallets](IPs/RSKIP57.md)         | 05-ABR-18 | IO | Usa    | Net      | 1 | Draft    |
 | 58       | [Handling Bitcoin Forks](IPs/RSKIP58.md)         | 14-NOV-17 | SDL | Sca    | Core      | 3 | Draft    |


### PR DESCRIPTION
Sets RSKIP-55 (Native On-Chain Probabilistic payments) to Rejected in the frontmatter, body table and README index — the proposal was never implemented (rskj-core carries no trace of native probabilistic payments) and has been rejected. Also aligns the README index title with the spec file's title.