### PR TITLE
RSKIP-59 (Child Contracts): set status to Rejected

### DIFF
--- a/IPs/RSKIP59.md
+++ b/IPs/RSKIP59.md
@@ -20,7 +20,7 @@ created: 2016-06-11
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |1 |
-|**Status**     |Rejected in favor of RSKIP125 |
+|**Status**     |Rejected |
 
 # **Abstract**
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 56       | [Sporadic Verification-less mining](IPs/RSKIP56.md)                                  | 11-MAR-17 | SDL       | Fair      | Core     | 3 | Draft   |
 | 57       | [Derivation Path for Hierarchical Deterministic Wallets](IPs/RSKIP57.md)         | 05-ABR-18 | IO | Usa    | Net      | 1 | Draft    |
 | 58       | [Handling Bitcoin Forks](IPs/RSKIP58.md)         | 14-NOV-17 | SDL | Sca    | Core      | 3 | Draft    |
-| 59       | [Child Contracts](IPs/RSKIP59.md)                                                | 11-JUN-16 | SDL       | Sca      | Core     | 1 | Accepted   |
+| 59       | [Child Contracts](IPs/RSKIP59.md)                                                | 11-JUN-16 | SDL       | Sca      | Core     | 1 | Rejected   |
 | 60       | [Checksum Address Encoding](IPs/RSKIP60.md)                                      | 25-JUN-18 | IO | ST     | Net      | 1 | Adopted   |
 | 61       | [Cache Oriented Storage Rent (collect at EOT version)](IPs/RSKIP61.md)           | 03-MAY-18 | SDL       | Sca      | Core     | 2 | Draft*   |
 | 62       | [Compressed block propagation using state trie update batch (COBLO)](IPs/RSKIP62.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Draft*   |


### PR DESCRIPTION
RSKIP-59 (Child Contracts) was rejected in favor of RSKIP125, as its own status table noted, but the README index still listed it as Accepted. This aligns the index and the body status table with the frontmatter's Rejected.