### PR TITLE
RSKIP-64 (Garbage Collector for State Pruning): set status to Adopted

### DIFF
--- a/IPs/RSKIP64.md
+++ b/IPs/RSKIP64.md
@@ -2,7 +2,7 @@
 rskip: 64
 title: Garbage Collector for State Pruning
 description: 
-status: Draft
+status: Adopted
 purpose: Sca, Usa
 author: SDL (@sergiodemianlerner), MMA
 layer: Core
@@ -20,7 +20,7 @@ created: 2018
 | **Purpose**    | Sca, Usa                            |
 | **Layer**      | Core                                |
 | **Complexity** | 2                                   |
-| **Status**     | Draft                               |
+| **Status**     | Adopted                             |
 
 ## Abstract
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 61       | [Cache Oriented Storage Rent (collect at EOT version)](IPs/RSKIP61.md)           | 03-MAY-18 | SDL       | Sca      | Core     | 2 | Draft*   |
 | 62       | [Compressed block propagation using state trie update batch (COBLO)](IPs/RSKIP62.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Draft*   |
 | 63       | [Double Signing for Delayed Signature Aggregation](IPs/RSKIP63.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Draft   |
-| 64       | [Garbage Collector for State Pruning](IPs/RSKIP64.md) | 29-MAY-18 | SDL & MMa | Sca,Usa      | Core     | 2 | Draft   |
+| 64       | [Garbage Collector for State Pruning](IPs/RSKIP64.md) | 29-MAY-18 | SDL & MMa | Sca,Usa      | Core     | 2 | Adopted |
 | 65       | [MINGASPRICE Opcode](IPs/RSKIP64.md)                                             | 18-MAY-18 | JIO       | Sec      | CORE     | 1 | DRAFT   |
 | 70       | [Default TX Data](IPs/RSKIP70.md)| 25-NOV-16 | SDL       | Sca      | Core     | 2 | Draft   |
 | 71  |[Transfer 2300 gas units for code execution in external transactions](IPs/RSKIP71.md) | 30-JAN-19 | SDL | Usa | Core | 1 | Draft |


### PR DESCRIPTION
Sets RSKIP-64 (Garbage Collector for State Pruning) to Adopted in the frontmatter, the body header table and the README index. The garbage collector ships in rskj — [`GarbageCollector.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/core/bc/GarbageCollector.java) wired as an InternalService in [`RskContext`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/RskContext.java), with [`MultiTrieStore.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/trie/MultiTrieStore.java) for epoch-rotated trie stores — configured via `blockchain.gc` in [`reference.conf`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/reference.conf) with `blocksPerEpoch=20000`, matching the spec's proposed N=20000. It is an opt-in node/storage feature (disabled by default), not a consensus rule, hence no activation flag.