### PR TITLE
RSKIP-70 (Default TX Data): set status to Withdrawn

### DIFF
--- a/IPs/RSKIP70.md
+++ b/IPs/RSKIP70.md
@@ -2,7 +2,7 @@
 rskip: 70
 title: Default TX Data
 description: 
-status: Draft
+status: Withdrawn
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -19,7 +19,7 @@ created: 2016-11-25
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |2 |
-|**Status**     |Draft |
+|**Status**     |Withdrawn |
 
 # **Abstract**
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 63       | [Double Signing for Delayed Signature Aggregation](IPs/RSKIP63.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Draft   |
 | 64       | [Garbage Collector for State Pruning](IPs/RSKIP64.md) | 29-MAY-18 | SDL & MMa | Sca,Usa      | Core     | 2 | Draft   |
 | 65       | [MINGASPRICE Opcode](IPs/RSKIP64.md)                                             | 18-MAY-18 | JIO       | Sec      | CORE     | 1 | DRAFT   |
-| 70       | [Default TX Data](IPs/RSKIP70.md)| 25-NOV-16 | SDL       | Sca      | Core     | 2 | Draft   |
+| 70       | [Default TX Data](IPs/RSKIP70.md)| 25-NOV-16 | SDL       | Sca      | Core     | 2 | Withdrawn   |
 | 71  |[Transfer 2300 gas units for code execution in external transactions](IPs/RSKIP71.md) | 30-JAN-19 | SDL | Usa | Core | 1 | Draft |
 | 75  |[Native Off-Chain Probabilistic payments](IPs/RSKIP75.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Draft   |
 | 77  |[Smoother Difficulty adjustment](IPs/RSKIP77.md) | 2016 | SDL | Sca, Fair | Core | 2 | Draft |


### PR DESCRIPTION
Aligns RSKIP-70's recorded status (frontmatter, body table, README index — all read Draft) to Withdrawn. rskj carries no trace of the proposal's default-data mechanism (no DDLOAD/DDSIZE/DDID/DDREMOVE opcodes or persistent-by-default tx data), and it builds directly on RSKIP-28's Ephemeral Data, part of the same 2016 shrinking-chain scaling group being closed out alongside it. Call is medium-confidence — if the idea is still alive, Deferred instead is a reasonable ask.