### PR TITLE
RSKIP-71 (Transfer 2300 gas units for code execution in external transactions): set status to Withdrawn

### DIFF
--- a/IPs/RSKIP71.md
+++ b/IPs/RSKIP71.md
@@ -2,7 +2,7 @@
 rskip: 71
 title: Transfer 2300 gas units for code execution in external transactions
 description: 
-status: Draft
+status: Withdrawn
 purpose: Usa
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -19,7 +19,7 @@ created: 2019
 | **Purpose**    | Usa                                                          |
 | **Layer**      | Core                                                         |
 | **Complexity** | 1                                                            |
-| **Status**     | Draft                                                        |
+| **Status**     | Withdrawn                                                    |
 
 # Abstract
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 64       | [Garbage Collector for State Pruning](IPs/RSKIP64.md) | 29-MAY-18 | SDL & MMa | Sca,Usa      | Core     | 2 | Draft   |
 | 65       | [MINGASPRICE Opcode](IPs/RSKIP64.md)                                             | 18-MAY-18 | JIO       | Sec      | CORE     | 1 | DRAFT   |
 | 70       | [Default TX Data](IPs/RSKIP70.md)| 25-NOV-16 | SDL       | Sca      | Core     | 2 | Draft   |
-| 71  |[Transfer 2300 gas units for code execution in external transactions](IPs/RSKIP71.md) | 30-JAN-19 | SDL | Usa | Core | 1 | Draft |
+| 71  |[Transfer 2300 gas units for code execution in external transactions](IPs/RSKIP71.md) | 30-JAN-19 | SDL | Usa | Core | 1 | Withdrawn |
 | 75  |[Native Off-Chain Probabilistic payments](IPs/RSKIP75.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Draft   |
 | 77  |[Smoother Difficulty adjustment](IPs/RSKIP77.md) | 2016 | SDL | Sca, Fair | Core | 2 | Draft |
 | 85  |[Remasc native contract improvements](IPs/RSKIP85.md) | 11-JUL-2018 | LS | Sca | Core | 2 | Adopted |


### PR DESCRIPTION
Sets the recorded status (frontmatter, body table, README index) from Draft to Withdrawn. The proposal — lower base transaction gas from 21000 to 18700 and forward a 2300 gas stipend to the receiver — was never implemented: the 18700 constant appears nowhere in rskj and base transaction gas remains 21000. If the idea is still alive, Deferred instead of Withdrawn is a fine call — happy to change it.