### PR TITLE
RSKIP-75 (Native Off-Chain Probabilistic payments): set status to Withdrawn

### DIFF
--- a/IPs/RSKIP75.md
+++ b/IPs/RSKIP75.md
@@ -2,7 +2,7 @@
 rskip: 75
 title: Native Off-Chain Probabilistic payments
 description: 
-status: Draft
+status: Withdrawn
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,7 @@ created: 2018-05-07
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |2 |
-|**Status**     |Draft |
+|**Status**     |Withdrawn |
 
 # **Abstract**
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 65       | [MINGASPRICE Opcode](IPs/RSKIP64.md)                                             | 18-MAY-18 | JIO       | Sec      | CORE     | 1 | DRAFT   |
 | 70       | [Default TX Data](IPs/RSKIP70.md)| 25-NOV-16 | SDL       | Sca      | Core     | 2 | Draft   |
 | 71  |[Transfer 2300 gas units for code execution in external transactions](IPs/RSKIP71.md) | 30-JAN-19 | SDL | Usa | Core | 1 | Draft |
-| 75  |[Native Off-Chain Probabilistic payments](IPs/RSKIP75.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Draft   |
+| 75  |[Native Off-Chain Probabilistic payments](IPs/RSKIP75.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Withdrawn |
 | 77  |[Smoother Difficulty adjustment](IPs/RSKIP77.md) | 2016 | SDL | Sca, Fair | Core | 2 | Draft |
 | 85  |[Remasc native contract improvements](IPs/RSKIP85.md) | 11-JUL-2018 | LS | Sca | Core | 2 | Adopted |
 | 87  |[Whitelisting unlimited mode](IPs/RSKIP87.md)| 12-JUL-18 | JD       | Usa      | Core     | 2 | Adopted   |


### PR DESCRIPTION
Sets the recorded status (frontmatter, body table, README index) from Draft to Withdrawn. A case-insensitive search of rskj-core for "probabilistic" finds no supporting classes, precompiles or wallet-side logic — this 2018 proposal was never implemented. Withdrawn was chosen over Deferred on that absence of activity; if the idea is still alive, Deferred works too.