### PR TITLE
RSKIP-98: fill in the activation height

### DIFF
--- a/IPs/RSKIP98.md
+++ b/IPs/RSKIP98.md
@@ -36,7 +36,7 @@ Therefore we propose that the system is forever deactivated in the next consensu
 
 # **Specification**
 
-If block number >= N (TBD), only blocks presenting a valid merge-mined proof-of-work will be accepted.
+If block number >= 729,000 (the [Orchid network upgrade](RSKIP99.md)), only blocks presenting a valid merge-mined proof-of-work will be accepted.
 
 # Backwards Compatibility
 


### PR DESCRIPTION
Replaces the Specification's `N (TBD)` placeholder with 729,000 — the Orchid network upgrade (RSKIP99), whose mainnet activation block is 729,000 per [`main.conf`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/config/main.conf). In rskj, [`ProofOfWorkRule.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/validators/ProofOfWorkRule.java) gates fallback-block rejection on `ConsensusRule.RSKIP98`, mapped to Orchid in [`reference.conf`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/reference.conf). Statuses already read Adopted everywhere; this is the row's only edit.