### PR TITLE
RSKIP-65: set status to Withdrawn

### DIFF
--- a/IPs/RSKIP65.md
+++ b/IPs/RSKIP65.md
@@ -2,7 +2,7 @@
 rskip: 65
 title: MINGASPRICE Opcode
 description: 
-status: Draft
+status: Withdrawn
 purpose: Sec
 author: JIO <jorlicki@iovlabs.org>
 layer: Core
@@ -20,7 +20,7 @@ created: 2018-05-11
 |**Purpose**    |Sec |
 |**Layer**      |Core |
 |**Complexity** |1 |
-|**Status**     |Draft |
+|**Status**     |Withdrawn |
 ## Abstract
 
 In this RSKIP we propose an extra opcode. It will provide non-native smart contracts access to current block information about Minimum Gas Price. This information will allow smart contracts to mitigate some financial behavior attacks, based on statistics, by making them economically infeasible, i.e. the attack cannot make money by statistically manipulating the contract. We can also deal with network congestion from the smart contract.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 62       | [Compressed block propagation using state trie update batch (COBLO)](IPs/RSKIP62.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Draft*   |
 | 63       | [Double Signing for Delayed Signature Aggregation](IPs/RSKIP63.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Draft   |
 | 64       | [Garbage Collector for State Pruning](IPs/RSKIP64.md) | 29-MAY-18 | SDL & MMa | Sca,Usa      | Core     | 2 | Draft   |
-| 65       | [MINGASPRICE Opcode](IPs/RSKIP65.md)                                             | 18-MAY-18 | JIO       | Sec      | CORE     | 1 | Withdrawn   |
+| 65       | [MINGASPRICE Opcode](IPs/RSKIP65.md)                                             | 18-MAY-18 | JIO       | Sec      | Core     | 1 | Withdrawn   |
 | 70       | [Default TX Data](IPs/RSKIP70.md)| 25-NOV-16 | SDL       | Sca      | Core     | 2 | Draft   |
 | 71  |[Transfer 2300 gas units for code execution in external transactions](IPs/RSKIP71.md) | 30-JAN-19 | SDL | Usa | Core | 1 | Draft |
 | 75  |[Native Off-Chain Probabilistic payments](IPs/RSKIP75.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Draft   |

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 62       | [Compressed block propagation using state trie update batch (COBLO)](IPs/RSKIP62.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Draft*   |
 | 63       | [Double Signing for Delayed Signature Aggregation](IPs/RSKIP63.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Draft   |
 | 64       | [Garbage Collector for State Pruning](IPs/RSKIP64.md) | 29-MAY-18 | SDL & MMa | Sca,Usa      | Core     | 2 | Draft   |
-| 65       | [MINGASPRICE Opcode](IPs/RSKIP64.md)                                             | 18-MAY-18 | JIO       | Sec      | CORE     | 1 | DRAFT   |
+| 65       | [MINGASPRICE Opcode](IPs/RSKIP65.md)                                             | 18-MAY-18 | JIO       | Sec      | CORE     | 1 | Withdrawn   |
 | 70       | [Default TX Data](IPs/RSKIP70.md)| 25-NOV-16 | SDL       | Sca      | Core     | 2 | Draft   |
 | 71  |[Transfer 2300 gas units for code execution in external transactions](IPs/RSKIP71.md) | 30-JAN-19 | SDL | Usa | Core | 1 | Draft |
 | 75  |[Native Off-Chain Probabilistic payments](IPs/RSKIP75.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Draft   |


### PR DESCRIPTION
Sets RSKIP-65 (MINGASPRICE opcode) to Withdrawn in the frontmatter, body table and README index: the opcode was never built (no MINGASPRICE in [`OpCode.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/vm/OpCode.java)) — the capability shipped instead via RSKIP-119 as the BlockHeaderContract precompile's [`GetMinimumGasPrice.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/pcc/blockheader/GetMinimumGasPrice.java).

Also fixes the README index row, which linked RSKIP-65's title to RSKIP64.md instead of RSKIP65.md.