### PR TITLE
RSKIP-68 (Federation Notification System): set status to Withdrawn

### DIFF
--- a/IPs/RSKIP68.md
+++ b/IPs/RSKIP68.md
@@ -2,7 +2,7 @@
 rskip: 68
 title: Federation Notification System
 description: 
-status: Draft
+status: Withdrawn
 purpose: Sec
 author: JIO <jorlicki@iovlabs.org>, SDL (@sergiodemianlerner)
 layer: Net
@@ -21,7 +21,7 @@ created: 2018-05-05
 |**Purpose**    |Sec |
 |**Layer**      |Net |
 |**Complexity** |2 |
-|**Status**     |Draft* |
+|**Status**     |Withdrawn |
 
 # Abstract
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 63       | [Double Signing for Delayed Signature Aggregation](IPs/RSKIP63.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Draft   |
 | 64       | [Garbage Collector for State Pruning](IPs/RSKIP64.md) | 29-MAY-18 | SDL & MMa | Sca,Usa      | Core     | 2 | Draft   |
 | 65       | [MINGASPRICE Opcode](IPs/RSKIP64.md)                                             | 18-MAY-18 | JIO       | Sec      | CORE     | 1 | DRAFT   |
+| 68       | [Federation Notification System](IPs/RSKIP68.md)                                 | 05-MAY-18 | SDL, JIO, DAM | Sec  | Net      | 2 | Withdrawn |
 | 70       | [Default TX Data](IPs/RSKIP70.md)| 25-NOV-16 | SDL       | Sca      | Core     | 2 | Draft   |
 | 71  |[Transfer 2300 gas units for code execution in external transactions](IPs/RSKIP71.md) | 30-JAN-19 | SDL | Usa | Core | 1 | Draft |
 | 75  |[Native Off-Chain Probabilistic payments](IPs/RSKIP75.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Draft   |


### PR DESCRIPTION
Sets RSKIP-68 (Federation Notification System) to Withdrawn in the file's frontmatter and body table, and adds its missing row to the README index. Code-verified: the feature was prototyped on rskj branch [`feature/rfs-199-federation-notifications`](https://github.com/rsksmart/rskj/tree/feature/rfs-199-federation-notifications) (May–Jul 2018) but was never merged — `origin/master` has no trace of it. Audit confidence was MEDIUM; if the idea is still alive, Deferred may fit better than Withdrawn — reviewer's call.