### PR TITLE
RSKIP-41 (Extended Bitcoin Bridge Transactions): set status to Deferred

### DIFF
--- a/IPs/RSKIP41.md
+++ b/IPs/RSKIP41.md
@@ -2,7 +2,7 @@
 rskip: 41
 title: Extended Bitcoin Bridge Transactions
 description: 
-status: Draft
+status: Deferred
 purpose: Usa
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,7 @@ created: 2017-04-25
 |**Purpose**    |Usa |
 |**Layer**      |Core |
 |**Complexity** |2 |
-|**Status**     |Draft | 
+|**Status**     |Deferred | 
 
 # **Abstract**
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 38       | [Signature Compression](IPs/RSKIP38.md)                                          | 21-FEB-17 | SDL       | Sca      | Core     | 3 | Draft    |
 | 39       | [Multi-key Accounts](IPs/RSKIP39.md)                                             | 25-FEB-17 | SDL       | Sca      | Core     | 2 | Draft    |
 | 40       | [Basic Bridge for two-way-peg to Bitcoin](IPs/RSKIP40.md)                        | 25-APR-17 | SDL       | Usa      | Core     | 2 | Adopted  |
-| 41       | [Extended Bitcoin Bridge Transactions](IPs/RSKIP41.md)                           | 25-APR-17 | SDL       | Usa      | Core     | 2 | Draft*   |
+| 41       | [Extended Bitcoin Bridge Transactions](IPs/RSKIP41.md)                           | 25-APR-17 | SDL       | Usa      | Core     | 2 | Deferred |
 | 42       | [Remove world midstates from receipts](IPs/RSKIP42.md)                           | 22-JUN-17 | SDL       | Sca      | Core     | 1 | Adopted  |
 | 43       | [Sequential Address format](IPs/RSKIP43.md)                                      | 23-JUN-17 | SDL       | Sca      | Core     | 2 | Draft    |
 | 44       | [Remove the zero-byte discount in data](IPs/RSKIP44.md)                          | 24-JUN-17 | SDL       | Sca      | Core     | 1 | Draft    |


### PR DESCRIPTION
Aligns the recorded status (frontmatter `Draft`, body table `Draft`, README index `Draft*`) to **Deferred**: the Extended Bitcoin Bridge Transactions scheme (EET / two-output redemption) has no implementation trace in rskj, and this 2017 draft extending RSKIP-40 saw no follow-up — parked, not rejected. Status-verification confidence was MEDIUM (Withdrawn was also considered); as the RSKIP's author, please confirm Deferred is the right call — or say if the idea should be revived or withdrawn instead.