### PR TITLE
RSKIP-4: set status to Withdrawn

### DIFF
--- a/IPs/RSKIP04.md
+++ b/IPs/RSKIP04.md
@@ -2,7 +2,7 @@
 rskip: 4
 title: Parallel Execution using runtime contract dependencies 
 description: This RSKIP describes how miners partition transactions into disjoint sets and how full nodes should process transactions in order to be safely parallelized. 
-status: Accepted
+status: Withdrawn
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,9 @@ created: 2016-06-22
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |2 |
-|**Status**     |Accepted |
+|**Status**     |Withdrawn |
+
+**This RSKIP is superseded by [RSKIP-144](RSKIP144.md)**
 
 # **Abstract**
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 1        | [Distributed Memory](IPs/RSKIP01.md)                                              | 09-JUN-16 | SDL       | Sca      | Core     | 2 | Draft    |
 | 2        | [Dynamic Contract Dependency](IPs/RSKIP02.md)                                     | 11-JUN-16 | SDL       | Sca      | Core     | 2 | Rejected |
 | 3        | [Parallel Execution using static contract dependencies](IPs/RSKIP03.md)           | 22-JUN-16 | SDL       | Sca      | Core     | 2 | Rejected |
-| 4        | [Parallel Execution using runtime contract dependencies](IPs/RSKIP04.md)          | 22-JUN-16 | SDL       | Sca      | Core     | 2 | Accepted |
+| 4        | [Parallel Execution using runtime contract dependencies](IPs/RSKIP04.md)          | 22-JUN-16 | SDL       | Sca      | Core     | 2 | Withdrawn |
 | 5        | [Shift Operations](IPs/RSKIP05.md)                                                | 22-JUN-16 | SDL       | Sca      | Core     | 1 | Rejected |
 | 6        | [Block Size Limit](IPs/RSKIP06.md)                                                | 22-JUN-16 | SDL       | Sca      | Core     | 1 | Adopted  |
 | 7        | [Persistent Storage Rent Paid by Code](IPs/RSKIP07.md)                            | 11-JUN-16 | SDL       | Sca      | Core     | 3 | Rejected |


### PR DESCRIPTION
Sets RSKIP-4's status to Withdrawn in the frontmatter, body header table and README index, and adds a supersession note. Per the RARF operator: RSKIP-4 was replaced by RSKIP-144 — rskj's parallel transaction execution ([`ParallelizeTransactionHandler.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/core/bc/ParallelizeTransactionHandler.java)) implements RSKIP-144's sublist model, gated by `RSKIP144` in [`ConsensusRule.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java); no RSKIP-4 runtime-dependency mechanism exists in the code.