### PR TITLE
RSKIP-108 (More Efficient Unitrie Key Mapping): set status to Deferred

### DIFF
--- a/IPs/RSKIP108.md
+++ b/IPs/RSKIP108.md
@@ -2,7 +2,7 @@
 rskip: 108
 title: More Efficient Unitrie Key Mapping
 description: 
-status: Draft
+status: Deferred
 purpose: Sca, Usa
 author: SDL (@sergiodemianlerner), AL <angel@iovlabs.org>
 layer: 
@@ -19,7 +19,7 @@ created: 2019
 |                |                                    |
 | **Layer**      | Sca, Usa                           |
 | **Complexity** | 2                                  |
-| **Status**     | Draft                              |
+| **Status**     | Deferred                           |
 
 # Abstract
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 102 |[Efficient and Secure Fee Bumping](IPs/RSKIP102.md) | 2018 | SDL | Usa  | Core | 2 | Draft |
 | 106 |[Precompiled contract for HDWallet utility functions](IPs/RSKIP106.md) | 2019 | AM | Usa  | Core | 1 | Adopted |
 | 107 |[Smaller Unitrie Nodes for Higher Scalability](IPs/RSKIP107.md) | 2019 | SDL | Sca | Core | 1 | Draft |
-| 108 |[More Efficient Unitrie Key Mapping](IPs/RSKIP108.md) | 2019 | SDL & AL | Usa,Sca  | Core | 2 | Draft |
+| 108 |[More Efficient Unitrie Key Mapping](IPs/RSKIP108.md) | 2019 | SDL & AL | Usa,Sca  | Core | 2 | Deferred |
 | 109 |[Lower Storage Gas Costs for Shorter Keys](IPs/RSKIP109.md) | 2019 | SDL  | Usa,Sca  | Core | 2 | Draft |
 | 110 |[Fork Detection Data in RSKBLOCK tags](IPs/RSKIP110.md) | 2019 | SDL  | Sec  | Core | 1 | Draft |
 | 112 |[Unitrie Node identifiers](IPs/RSKIP112.md) | 2019 | SDL  | Sec,Sca  | Core | 1 | Draft |


### PR DESCRIPTION
Sets RSKIP-108's status to Deferred in the frontmatter, body header table and README index (all read Draft). The proposal's 80-bit-hash-prefix key mapping ships in rskj's [`TrieKeyMapper.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/db/TrieKeyMapper.java) (`SECURE_KEY_SIZE = 10`, leading-zero-stripped storage subkeys), so the proposal is not withdrawn — but its companion gas-cost incentives (RSKIP109) show no adoption trace, hence Deferred rather than Adopted. The status call is a judgment on a partially-implemented proposal; worth a second look from the author.