### PR TITLE
RSKIP-62 (Compressed block propagation using state trie update batch): set status to Withdrawn

### DIFF
--- a/IPs/RSKIP62.md
+++ b/IPs/RSKIP62.md
@@ -1,8 +1,8 @@
 ---
 rskip: 62
-title: Compressed block propagation using state trie update batch
+title: Compressed block propagation using state trie update batch (COBLO)
 description: 
-status: Draft
+status: Withdrawn
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -19,7 +19,7 @@ created: 2018-05-07
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |2 |
-|**Status**     |Draft |
+|**Status**     |Withdrawn |
 
 # **Abstract**
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 59       | [Child Contracts](IPs/RSKIP59.md)                                                | 11-JUN-16 | SDL       | Sca      | Core     | 1 | Accepted   |
 | 60       | [Checksum Address Encoding](IPs/RSKIP60.md)                                      | 25-JUN-18 | IO | ST     | Net      | 1 | Adopted   |
 | 61       | [Cache Oriented Storage Rent (collect at EOT version)](IPs/RSKIP61.md)           | 03-MAY-18 | SDL       | Sca      | Core     | 2 | Draft*   |
-| 62       | [Compressed block propagation using state trie update batch (COBLO)](IPs/RSKIP62.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Draft*   |
+| 62       | [Compressed block propagation using state trie update batch (COBLO)](IPs/RSKIP62.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Withdrawn|
 | 63       | [Double Signing for Delayed Signature Aggregation](IPs/RSKIP63.md)| 07-MAY-18 | SDL       | Sca      | Core     | 2 | Draft   |
 | 64       | [Garbage Collector for State Pruning](IPs/RSKIP64.md) | 29-MAY-18 | SDL & MMa | Sca,Usa      | Core     | 2 | Draft   |
 | 65       | [MINGASPRICE Opcode](IPs/RSKIP64.md)                                             | 18-MAY-18 | JIO       | Sec      | CORE     | 1 | DRAFT   |


### PR DESCRIPTION
Sets the status to Withdrawn in the frontmatter, body table and README index, and adds the (COBLO) suffix to the frontmatter title to match the spec's own heading and the index. rskj carries no trace of this 2018 proposal — its distinctive mechanisms (COBLO, state-trie change batches, compressed transaction ids) don't appear anywhere in rskj-core, and block propagation has no headers-first compression. This call is medium-confidence: with no sign of active work we defaulted to Withdrawn, but if the idea is still alive, Deferred may fit better — your call as the author.