### PR TITLE
RSKIP-113: set status to Withdrawn

### DIFF
--- a/IPs/RSKIP113.md
+++ b/IPs/RSKIP113.md
@@ -2,7 +2,7 @@
 rskip: 113
 title: Unified Cache-Oriented Storage Rent for the Unitrie
 description: 
-status: Draft
+status: Withdrawn
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -19,7 +19,7 @@ created: 2019
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |2 |
-|**Status**     |Draft |
+|**Status**     |Withdrawn |
 
 # **Abstract**
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 109 |[Lower Storage Gas Costs for Shorter Keys](IPs/RSKIP109.md) | 2019 | SDL  | Usa,Sca  | Core | 2 | Draft |
 | 110 |[Fork Detection Data in RSKBLOCK tags](IPs/RSKIP110.md) | 2019 | SDL  | Sec  | Core | 1 | Draft |
 | 112 |[Unitrie Node identifiers](IPs/RSKIP112.md) | 2019 | SDL  | Sec,Sca  | Core | 1 | Draft |
-| 113 |[Unified Cache Oriented Storage Rent for the Unitrie](IPs/RSKIP113.md) | 2019 | SDL  | Sec,Sca  | Core | 2 | Draft |
+| 113 |[Unified Cache-Oriented Storage Rent for the Unitrie](IPs/RSKIP113.md) | 2019 | SDL  | Sec,Sca  | Core | 2 | Withdrawn |
 | 115 |[Removal of Unused Headers from the Bridge Contract](IPs/RSKIP115.md) | 2019 | SDL  | Sca  | Core | 2 | Draft |
 | 116 |[Failure of SSTORE on Low-Gas Recursive CALLs](IPs/RSKIP116.md) | 2019 | SDL  | Sec,Sca,Usa  | Core | 1 | Draft |
 | 119 |[Precompiled contract for inspecting block headers](IPs/RSKIP119.md) | 2019 | DM  | Usa  | Core | 1 | Draft |


### PR DESCRIPTION
Sets RSKIP-113 (Unified Cache-Oriented Storage Rent for the Unitrie) to **Withdrawn** in the frontmatter, the body status table and the README index, and fixes the index title to the file's own hyphenated form.

The storage-rent line was withdrawn by its author: no rent fields or rent logic exist in rskj's repository/trie code.
