### PR TITLE
RSKIP-518: fill Reed activation heights, align frontmatter title

### DIFF
--- a/IPs/RSKIP518.md
+++ b/IPs/RSKIP518.md
@@ -1,6 +1,6 @@
 ---
 rskip: 518
-title: Network Upgrade - Reed
+title: "Network Upgrade: Reed"
 description: 
 status: Adopted
 purpose: Usa, Sca
@@ -30,10 +30,10 @@ This RSKIP outlines the consensus changes proposed for inclusion in Rootstock’
 - Codename: Reed
 - Block activations for Reed 8.0.0:
 	- Rootstock Mainnet block: 8,052,200
-	- Rootstock Testnet block: 6,835,655
+	- Rootstock Testnet block: 6,835,700
 - Block activations for Reed 8.1.0:
 	- Rootstock Mainnet block: N/A
-	- Rootstock Testnet block: TBD
+	- Rootstock Testnet block: 7,139,600
 
 ### Included RSKIPs
 


### PR DESCRIPTION
Fills Reed 8.1.0's Rootstock Testnet activation (TBD → 7,139,600) and corrects Reed 8.0.0's Testnet height (6,835,655 → 6,835,700), both per rskj's [`testnet.conf`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/config/testnet.conf) (`reed810 = 7139600`, `reed800 = 6835700`; [`main.conf`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/config/main.conf) keeps `reed810 = -1`, so the Mainnet N/A stands). Also aligns the frontmatter title to the document's own "Network Upgrade: Reed", matching the H1, body table and README index.