### PR TITLE
RSKIP-107 (Smaller Unitrie Nodes for Higher Scalability): set status to Adopted

### DIFF
--- a/IPs/RSKIP107.md
+++ b/IPs/RSKIP107.md
@@ -2,7 +2,7 @@
 rskip: 107
 title: Smaller Unitrie Nodes for Higher Scalability
 description: 
-status: Draft
+status: Adopted
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -19,7 +19,7 @@ created: 2019
 | **Purpose**    | Sca                                          |
 | **Layer**      | Core                                         |
 | **Complexity** | 1                                            |
-| **Status**     | Draft                                        |
+| **Status**     | Adopted                                      |
 
 # Abstract
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 99  |[Orchid Network Upgrade](IPs/RSKIP99.md) | 2018 | AE | Scan,Sec,Usa | Core | 3 | Adopted |
 | 102 |[Efficient and Secure Fee Bumping](IPs/RSKIP102.md) | 2018 | SDL | Usa  | Core | 2 | Draft |
 | 106 |[Precompiled contract for HDWallet utility functions](IPs/RSKIP106.md) | 2019 | AM | Usa  | Core | 1 | Adopted |
-| 107 |[Smaller Unitrie Nodes for Higher Scalability](IPs/RSKIP107.md) | 2019 | SDL | Sca | Core | 1 | Draft |
+| 107 |[Smaller Unitrie Nodes for Higher Scalability](IPs/RSKIP107.md) | 2019 | SDL | Sca | Core | 1 | Adopted |
 | 108 |[More Efficient Unitrie Key Mapping](IPs/RSKIP108.md) | 2019 | SDL & AL | Usa,Sca  | Core | 2 | Draft |
 | 109 |[Lower Storage Gas Costs for Shorter Keys](IPs/RSKIP109.md) | 2019 | SDL  | Usa,Sca  | Core | 2 | Draft |
 | 110 |[Fork Detection Data in RSKBLOCK tags](IPs/RSKIP110.md) | 2019 | SDL  | Sec  | Core | 1 | Draft |


### PR DESCRIPTION
Aligns the recorded status (frontmatter, body table, README index) with the implementation: the RSKIP-107 node format ships in rskj under its own name. [`Trie.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/trie/Trie.java) dispatches deserialization on the first byte (legacy Orchid vs `fromMessageRskip107`), and `internalToMessage` writes the spec's format exactly — version bits `01`, the hasLongValue/sharedPrefixPresent/present/embedded flag layout, Uint8-prefixed embedded terminal children, valueHash + uint24 length for long values, and a VarInt tree size when children exist. [`SharedPathSerializer.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/trie/SharedPathSerializer.java) implements the spec's three-range compressed prefix length verbatim (0–31 → +1, 32–254 → +128, 255 → Bitcoin VarInt). This is not merely an alternate parser: `Trie.getHash()` hashes the RSKIP-107 encoding, so state-trie node hashes — and the state root — are computed over it. The format is consensus-active in every current node.