### PR TITLE
RSKIP-109 (Lower Storage Gas Costs for Shorter Keys): set status to Withdrawn

### DIFF
--- a/IPs/RSKIP109.md
+++ b/IPs/RSKIP109.md
@@ -2,7 +2,7 @@
 rskip: 109
 title:  Lower Storage Gas Costs for Shorter Keys 
 description: 
-status: Draft
+status: Withdrawn
 purpose: Sca, Usa
 author: SDL (@sergiodemianlerner)
 layer: 
@@ -18,7 +18,7 @@ created: 2019
 | **Author**     | SDL                                      |
 | **Layer**      | Sca, Usa                                 |
 | **Complexity** | 2                                        |
-| **Status**     | Draft                                    |
+| **Status**     | Withdrawn                                |
 
 # Abstract
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 106 |[Precompiled contract for HDWallet utility functions](IPs/RSKIP106.md) | 2019 | AM | Usa  | Core | 1 | Adopted |
 | 107 |[Smaller Unitrie Nodes for Higher Scalability](IPs/RSKIP107.md) | 2019 | SDL | Sca | Core | 1 | Draft |
 | 108 |[More Efficient Unitrie Key Mapping](IPs/RSKIP108.md) | 2019 | SDL & AL | Usa,Sca  | Core | 2 | Draft |
-| 109 |[Lower Storage Gas Costs for Shorter Keys](IPs/RSKIP109.md) | 2019 | SDL  | Usa,Sca  | Core | 2 | Draft |
+| 109 |[Lower Storage Gas Costs for Shorter Keys](IPs/RSKIP109.md) | 2019 | SDL  | Usa,Sca  | Core | 2 | Withdrawn |
 | 110 |[Fork Detection Data in RSKBLOCK tags](IPs/RSKIP110.md) | 2019 | SDL  | Sec  | Core | 1 | Draft |
 | 112 |[Unitrie Node identifiers](IPs/RSKIP112.md) | 2019 | SDL  | Sec,Sca  | Core | 1 | Draft |
 | 113 |[Unified Cache Oriented Storage Rent for the Unitrie](IPs/RSKIP113.md) | 2019 | SDL  | Sec,Sca  | Core | 2 | Draft |


### PR DESCRIPTION
Aligns RSKIP-109's recorded status (frontmatter, body table, README index) from Draft to Withdrawn. The proposed key-length-dependent storage gas scheme never landed in rskj: [`GasCost.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/vm/GasCost.java) still carries flat SSTORE costs (300/5000/20000) with no variable-by-key-length pricing. The audit's confidence here is MEDIUM — if the idea is still alive, Deferred may fit better than Withdrawn; your call as the RSKIP's author.