### PR TITLE
RSKIP-115 (Removal of Unused Headers from the Bridge Contract): set status to Withdrawn

### DIFF
--- a/IPs/RSKIP115.md
+++ b/IPs/RSKIP115.md
@@ -2,7 +2,7 @@
 rskip: 115
 title: Removal of Unused Headers from the Bridge Contract
 description: 
-status: Draft
+status: Withdrawn
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -19,7 +19,7 @@ created: 2019
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |2 |
-|**Status**     |Draft |
+|**Status**     |Withdrawn |
 
 # **Abstract**
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 110 |[Fork Detection Data in RSKBLOCK tags](IPs/RSKIP110.md) | 2019 | SDL  | Sec  | Core | 1 | Draft |
 | 112 |[Unitrie Node identifiers](IPs/RSKIP112.md) | 2019 | SDL  | Sec,Sca  | Core | 1 | Draft |
 | 113 |[Unified Cache Oriented Storage Rent for the Unitrie](IPs/RSKIP113.md) | 2019 | SDL  | Sec,Sca  | Core | 2 | Draft |
-| 115 |[Removal of Unused Headers from the Bridge Contract](IPs/RSKIP115.md) | 2019 | SDL  | Sca  | Core | 2 | Draft |
+| 115 |[Removal of Unused Headers from the Bridge Contract](IPs/RSKIP115.md) | 2019 | SDL  | Sca  | Core | 2 | Withdrawn |
 | 116 |[Failure of SSTORE on Low-Gas Recursive CALLs](IPs/RSKIP116.md) | 2019 | SDL  | Sec,Sca,Usa  | Core | 1 | Draft |
 | 119 |[Precompiled contract for inspecting block headers](IPs/RSKIP119.md) | 2019 | DM  | Usa  | Core | 1 | Draft |
 | 120 |[Shifting opcodes](IPs/RSKIP120.md) | 2019 | SMS  | Sca  | Core | 1 | Adopted |


### PR DESCRIPTION
Sets RSKIP-115 (Removal of Unused Headers from the Bridge Contract) to Withdrawn in the frontmatter, body table and README index (all read Draft). Neither the proposed `registerOldBtcTransaction` method nor an `oldList`/header-pruning structure exists in rskj-core — the [`Bridge`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/peg/Bridge.java) still retains full BTC header history, and there is no sign of active work. Medium confidence: Withdrawn was chosen over Deferred on the absence of activity — if the idea is still alive, please say so and this can land as Deferred instead.