### PR TITLE
RSKIP-120 (Shifting opcodes): set status to Adopted

### DIFF
--- a/IPs/RSKIP120.md
+++ b/IPs/RSKIP120.md
@@ -2,7 +2,7 @@
 rskip: 120
 title: Shifting opcodes  
 description: 
-status: Draft
+status: Adopted
 purpose: Sca
 author: SMS (@sebastians)
 layer: Core
@@ -19,7 +19,7 @@ created: 2019-04-23
 |**Purpose**    |Sca |
 |**Layer**      |Core|
 |**Complexity** | 1 |
-|**Status**     |Draft |
+|**Status**     |Adopted |
 
 ## Abstract
 


### PR DESCRIPTION
Sets the RSKIP-120 file's status (frontmatter and body table) to Adopted, matching the README index. The shifting opcodes ship in rskj: SHL/SHR/SAR are implemented in [`VM.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/vm/VM.java), activation-gated behind RSKIP120 in [`ConsensusRule.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java).