### PR TITLE
RSKIP-131: set status to Adopted

### DIFF
--- a/IPs/RSKIP131.md
+++ b/IPs/RSKIP131.md
@@ -2,7 +2,7 @@
 rskip: 131
 title: Preventing CREATE2-after-SUICIDE in the same block
 description: 
-status: Draft
+status: Adopted
 purpose: Sca, Usa
 author: SMS (@sebastians), SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,7 @@ created: 2019-06-10
 |**Purpose**    |Sca, Usa |
 |**Layer**      |Core |
 |**Complexity** |1 |
-|**Status**     |Draft |
+|**Status**     |Adopted |
 
 ## Abstract
 


### PR DESCRIPTION
Aligns the RSKIP file's frontmatter and body-table status (Draft → Adopted) with the README index. The deleted-in-same-block creation check ships in [`Program.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/vm/program/Program.java) (`createContract` fails with an address collision, zero pushed, all gas spent), gated by [`ConsensusRule.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java)'s RSKIP125 — per the RSKIP's own note that it ships tied to RSKIP125 — and active on mainnet since wasabi100 ([`main.conf`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/config/main.conf) block 1,591,000), with test coverage in [`createAfterSuicide.txt`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/test/resources/dsl/createAfterSuicide.txt).