### PR TITLE
RSKIP-149 (Improved asset transfers): set status to Withdrawn

### DIFF
--- a/IPs/RSKIP149.md
+++ b/IPs/RSKIP149.md
@@ -2,7 +2,7 @@
 rskip: 149
 title: Improved asset transfers
 description: 
-status: Draft 
+status: Withdrawn 
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -19,7 +19,7 @@ created: 2019-11
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |2 |
-|**Status**     |Draft |
+|**Status**     |Withdrawn |
 
 # **Abstract**
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 145 |[Struct Transaction Format](IPs/RSKIP145.md)|  20-FEB-17 | SDL | Sca | Core | 2 | Draft |
 | 146 |[Encode bridge events in Solidity format](IPs/RSKIP146.md)|  25-OCT-19 | MI & JD | Usa | Core | 2 | Adopted |
 | 148 |[ERC1820 Pseudo-introspection Registry Contract](IPs/RSKIP148.md)|  6-NOV-19 | PMP | Usa | DApp | 1 | Adopted |
-| 149 |[Improved Asset transfers](IPs/RSKIP149.md)|  10-NOV-19 | SDL | Sca | Core | 2 | Draft |
+| 149 |[Improved Asset transfers](IPs/RSKIP149.md)|  10-NOV-19 | SDL | Sca | Core | 2 | Withdrawn |
 | 152 |[CHAINID Opcode](IPs/RSKIP152.md)|  19-NOV-19 | SMS | Sec | Core | 1 | Draft |
 | 153 |[Add BLAKE2 Compression Function `F` Precompile](IPs/RSKIP153.md)|  19-NOV-20 | FJ | Usa | Core | 2 | Adopted |
 | 157 |[Cumulative Difficulty in JSON-RPC block responses](IPs/RSKIP157.md)|  11-FEB-20 | MP | Usa | Node | 1 | Accepted |


### PR DESCRIPTION
Sets RSKIP-149's status to Withdrawn in the frontmatter, body table and README index. RSKIP-144's parallel transaction execution ships in rskj behind the reed810 upgrade ([`ConsensusRule.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java)) and detects conflicts per storage cell ([`ParallelizeTransactionHandler.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/core/bc/ParallelizeTransactionHandler.java), [`MutableRepository.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/db/MutableRepository.java)), so same-token ERC-20 transfers already parallelize when they touch different balance slots. The commutative balance primitives (BADD/BSUB) this RSKIP proposed for the remaining same-slot case were never implemented and show no active work; the status call is medium-confidence — if the idea is still alive, Deferred may fit better.