### PR TITLE
RSKIP-152: set status to Adopted

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 146 |[Encode bridge events in Solidity format](IPs/RSKIP146.md)|  25-OCT-19 | MI & JD | Usa | Core | 2 | Adopted |
 | 148 |[ERC1820 Pseudo-introspection Registry Contract](IPs/RSKIP148.md)|  6-NOV-19 | PMP | Usa | DApp | 1 | Adopted |
 | 149 |[Improved Asset transfers](IPs/RSKIP149.md)|  10-NOV-19 | SDL | Sca | Core | 2 | Draft |
-| 152 |[CHAINID Opcode](IPs/RSKIP152.md)|  19-NOV-19 | SMS | Sec | Core | 1 | Draft |
+| 152 |[CHAINID Opcode](IPs/RSKIP152.md)|  19-NOV-19 | SMS | Sec | Core | 1 | Adopted |
 | 153 |[Add BLAKE2 Compression Function `F` Precompile](IPs/RSKIP153.md)|  19-NOV-20 | FJ | Usa | Core | 2 | Adopted |
 | 157 |[Cumulative Difficulty in JSON-RPC block responses](IPs/RSKIP157.md)|  11-FEB-20 | MP | Usa | Node | 1 | Accepted |
 | 159 |[Minimal Proxy Contract](IPs/RSKIP159.md)|  19-FEB-20 | PMP | Usa | DApp | 1 | Adopted |


### PR DESCRIPTION
Aligns the README index status for RSKIP-152 (CHAINID Opcode) from Draft to Adopted, matching the RSKIP file's own frontmatter and body table. The opcode ships in rskj: implemented in [`VM.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/vm/VM.java) and activation-gated behind RSKIP152 in [`ConsensusRule.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java).