### PR TITLE
RSKIP-153: set status to Adopted

### DIFF
--- a/IPs/RSKIP153.md
+++ b/IPs/RSKIP153.md
@@ -2,7 +2,7 @@
 rskip: 153
 title: Add BLAKE2 Compression Function `F` Precompile 
 description: 
-status: Accepted
+status: Adopted
 purpose: Usa
 author: FJ (@fedejinich)
 layer: Core
@@ -19,7 +19,7 @@ created: 2020-11-19
 |**Purpose**    |Usa |
 |**Layer**      |Core |
 |**Complexity** |2 |
-|**Status**     |Accepted |
+|**Status**     |Adopted |
 
 ## Abstract
 


### PR DESCRIPTION
Sets the RSKIP-153 (Blake2F precompile) status to Adopted in the file's frontmatter and body table, matching the README index. The precompile ships in rskj: [`PrecompiledContracts.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/vm/PrecompiledContracts.java) registers Blake2F gated behind RSKIP153 in [`ConsensusRule.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java).