### PR TITLE
RSKIP-157: set status to Adopted

### DIFF
--- a/IPs/RSKIP157.md
+++ b/IPs/RSKIP157.md
@@ -2,7 +2,7 @@
 rskip: 157
 title: Cumulative Difficulty in JSON-RPC block responses
 description: 
-status: Draft
+status: Adopted
 purpose: Usa
 author: MP <mpicco@iovlabs.org>
 layer: Node
@@ -19,7 +19,7 @@ created: 2020-02-11
 |**Purpose**    |Usa |
 |**Layer**      |Node |
 |**Complexity** |1 |
-|**Status**     |Draft |
+|**Status**     |Adopted |
 
 ## Abstract
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 149 |[Improved Asset transfers](IPs/RSKIP149.md)|  10-NOV-19 | SDL | Sca | Core | 2 | Draft |
 | 152 |[CHAINID Opcode](IPs/RSKIP152.md)|  19-NOV-19 | SMS | Sec | Core | 1 | Draft |
 | 153 |[Add BLAKE2 Compression Function `F` Precompile](IPs/RSKIP153.md)|  19-NOV-20 | FJ | Usa | Core | 2 | Adopted |
-| 157 |[Cumulative Difficulty in JSON-RPC block responses](IPs/RSKIP157.md)|  11-FEB-20 | MP | Usa | Node | 1 | Accepted |
+| 157 |[Cumulative Difficulty in JSON-RPC block responses](IPs/RSKIP157.md)|  11-FEB-20 | MP | Usa | Node | 1 | Adopted |
 | 159 |[Minimal Proxy Contract](IPs/RSKIP159.md)|  19-FEB-20 | PMP | Usa | DApp | 1 | Adopted |
 | 167 |[Install Code Precompile](IPs/RSKIP167.md)|  07-JUL-20 | SDL | Usa | Core | 1 | Draft |
 | 169 |[Rectify EXTCODEHASH implementation](IPs/RSKIP169.md)|  31-JUL-20 | NPS | Usa | Core | 2 | Adopted |


### PR DESCRIPTION
Aligns RSKIP-157's recorded status (README index said Accepted, the file said Draft) to Adopted: the `cumulativeDifficulty` field ships in rskj's JSON-RPC block responses ([`BlockResultDTO.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/rpc/dto/BlockResultDTO.java)).