### PR TITLE
RSKIP-173 (Chunk-Based Code Merkleization using the Unitrie): set status to Withdrawn

### DIFF
--- a/IPs/RSKIP173.md
+++ b/IPs/RSKIP173.md
@@ -2,7 +2,7 @@
 rskip: 173
 title: Chunk-Based Code Merkleization using the Unitrie
 description: 
-status: Draft
+status: Withdrawn
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,7 @@ created: 2020-09
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |2 |
-|**Status**     |Draft |
+|**Status**     |Withdrawn |
 
 
 # **Abstract**

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 170 |[Peg-in to any address](IPs/RSKIP170.md)|  01-SEP-20 | MI | Usa | Core | 2 | Adopted |
 | 171 |[Clean EVM Internal Buffer in Call-like Opcodes](IPs/RSKIP171.md)|  02-SEP-20 | FJ | Usa | Core | 1 | Adopted |
 | 172 |[Simple Subroutines for the EVM](IPs/RSKIP172.md)|  01-SEP-20 | AL | Usa | Core | 2 | Draft |
-| 173 |[Chunk-Based Code Merkleization using the Unitrie](IPs/RSKIP173.md)|  10-SEP-20 | SDL | Sca | Core | 2 | Draft |
+| 173 |[Chunk-Based Code Merkleization using the Unitrie](IPs/RSKIP173.md)|  10-SEP-20 | SDL | Sca | Core | 2 | Withdrawn |
 | 174 |[Preserve balance in contract creation](IPs/RSKIP174.md)| 23-JUL-21 | VK | Usa/Fair | Core | 1 | Adopted |
 | 176 |[Programmable Peg-in Addresses for faster peg-ins](IPs/RSKIP176.md)| 15-SEP-20 | SDL,GM | Usa | Core | 2 | Adopted |
 | 177 |[Universal Merged Mining Extension](IPs/RSKIP177.md)|  APR-2020 | SDL & MP | Usa | Node | 1 | Adopted |


### PR DESCRIPTION
Sets the status to Withdrawn in the frontmatter, the body table and the README index (all read Draft). rskj carries no chunk-based code merkleization implementation — the only chunk-handling code, e.g. [`TrieDTOInOrderIterator.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/trie/TrieDTOInOrderIterator.java), belongs to snap-sync state transfer — and there is no sign of active work. The status call is medium-confidence: if the idea is still alive, Deferred may fit better — reviewer's call.