### PR TITLE
RSKIP-171: set status to Adopted

### DIFF
--- a/IPs/RSKIP171.md
+++ b/IPs/RSKIP171.md
@@ -2,7 +2,7 @@
 rskip: 171
 title: Clean EVM Internal Buffer in Call-like Opcodes
 description: 
-status: Accepted
+status: Adopted
 purpose: Usa
 author: FJ (@fedejinich)
 layer: Core
@@ -19,7 +19,7 @@ created: 2020-02-09
 |**Purpose**    |Usa |
 |**Layer**      |Core |
 |**Complexity** |1 |
-|**Status**     |Accepted |
+|**Status**     |Adopted |
 
 ## Abstract
 


### PR DESCRIPTION
Sets the RSKIP file's frontmatter and body-table status to Adopted, matching the README index. The rule ships in rskj — [`ConsensusRule.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java) defines RSKIP171, enforced in [`Program.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/vm/program/Program.java) — and is activated at iris300 ([`reference.conf`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/reference.conf)).