### PR TITLE
RSKIP-197: set status to Adopted

### DIFF
--- a/IPs/RSKIP197.md
+++ b/IPs/RSKIP197.md
@@ -2,7 +2,7 @@
 rskip: 197
 title: Fix Precompile Calls Not Conforming With CALL Semantics
 description: 
-status: Accepted
+status: Adopted
 purpose: Usa
 author: FJ (@fedejinich)
 layer: Core
@@ -19,7 +19,7 @@ created: 2020-12-15
 |**Purpose**    |Usa |
 |**Layer**      |Core |
 |**Complexity** |2 |
-|**Status**     |Accepted |
+|**Status**     |Adopted |
 
 ## Motivation
 


### PR DESCRIPTION
Sets the frontmatter and body-table status to Adopted, matching the README index. The fix ships in rskj as [`ConsensusRule.RSKIP197`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java), activated at Iris (`rskip197 = iris300` in [`reference.conf`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/reference.conf)).