### PR TITLE
RSKIP-218: set status to Adopted

### DIFF
--- a/IPs/RSKIP218.md
+++ b/IPs/RSKIP218.md
@@ -2,7 +2,7 @@
 rskip: 218
 title: New Fee Rewards Address for the RSK Core Developers Fund
 description: 
-status: Accepted
+status: Adopted
 purpose: Usa
 author: FJ (@fedejinich)
 layer: Core
@@ -19,7 +19,7 @@ created: 2021-03-25
 |**Purpose**    |Usa |
 |**Layer**      |Core |
 |**Complexity** |1 |
-|**Status**     |Accepted |
+|**Status**     |Adopted |
 
 ## Abstract
 


### PR DESCRIPTION
Sets the file's frontmatter and body-table status from Accepted to Adopted, matching the README index. The change ships in rskj: gated behind ConsensusRule.RSKIP218 in [`Remasc.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/remasc/Remasc.java), activated at iris300 per [`reference.conf`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/reference.conf).