### PR TITLE
RSKIP-284: set status to Adopted

### DIFF
--- a/IPs/RSKIP284.md
+++ b/IPs/RSKIP284.md
@@ -8,7 +8,7 @@
 |**Purpose**    |Usa, Sec|
 |**Layer**      |Core |
 |**Complexity** |1|
-|**Status**     |Accepted|
+|**Status**     |Adopted|
 
 ## Abstract
 


### PR DESCRIPTION
Sets the document's header-table status to Adopted, matching the README index, which already records it as Adopted (the file carries no frontmatter). The Flyover refund-address deserialization fix this RSKIP specifies is implemented in rskj, so Adopted is the code-verified status.