### PR TITLE
RSKIP-297: set status to Adopted

### DIFF
--- a/IPs/RSKIP297.md
+++ b/IPs/RSKIP297.md
@@ -8,7 +8,7 @@
 |**Purpose**    |Usa |
 |**Layer**      |Core |
 |**Complexity** |1 |
-|**Status**     |Accepted |
+|**Status**     |Adopted |
 
 ## Abstract
 


### PR DESCRIPTION
Sets the status in RSKIP297's body header table to Adopted (it read Accepted; the README index already says Adopted, and the file has no frontmatter). The change ships in rskj: [`Constants.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/config/Constants.java)'s `getMaxTimestampsDiffInSecs` returns the raised testnet limit when [`ConsensusRule.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java)'s RSKIP297 is active.