### PR TITLE
RSKIP-294: set status to Adopted

### DIFF
--- a/IPs/RSKIP294.md
+++ b/IPs/RSKIP294.md
@@ -8,7 +8,7 @@
 |**Purpose**    |Sca,Sec |
 |**Layer**      |Core |
 |**Complexity** |1 |
-|**Status**     |Accepted |
+|**Status**     |Adopted |
 
 ## Abstract
 


### PR DESCRIPTION
Sets the status in the file's header table to Adopted, matching the README index. The limit on migration-transaction inputs ships in rskj: gated behind `RSKIP294` in [`ConsensusRule.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java), activated at the Hop 4.0.0 upgrade ([`reference.conf`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/reference.conf)), and enforced in [`BridgeSupport.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/peg/BridgeSupport.java).