### PR TITLE
RSKIP-293: set status to Adopted

### DIFF
--- a/IPs/RSKIP293.md
+++ b/IPs/RSKIP293.md
@@ -8,7 +8,7 @@
 |**Purpose**    |Usa,Sec |
 |**Layer**      |Core |
 |**Complexity** |2 |
-|**Status**     |Accepted |
+|**Status**     |Adopted |
 
 ## Abstract
 


### PR DESCRIPTION
Aligns the RSKIP file's status table to Adopted, matching the README index. The Flyover peg-in improvements ship in rskj gated behind `RSKIP293` in [`ConsensusRule.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java).