### PR TITLE
RSKIP-179: set status to Adopted

### DIFF
--- a/IPs/RSKIP179.md
+++ b/IPs/RSKIP179.md
@@ -2,7 +2,7 @@
 rskip: 179
 title: BTC-RSK timestamp linking
 description: 
-status: Draft
+status: Adopted
 purpose: Sec
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,7 +20,7 @@ created: 2020-10
 |**Purpose**    |Sec |
 |**Layer**      |Core |
 |**Complexity** |1 |
-|**Status**     |Draft |
+|**Status**     |Adopted |
 |**discussions-to**     |https://research.rsk.dev/t/rskip-179-btc-rsk-timestamp-linking/44 |
 
 


### PR DESCRIPTION
Sets RSKIP-179's frontmatter and body-table status to Adopted, matching the README index. The rule ships in rskj as [`ConsensusRule.RSKIP179`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java), activated at iris300 ([`reference.conf`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/reference.conf)), and [`BlockTimeStampValidationRule`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/validators/BlockTimeStampValidationRule.java) enforces the spec's BTC–RSK timestamp bound on every block once active.