### PR TITLE
RSKIP-298: set status to Withdrawn

### DIFF
--- a/IPs/RSKIP298.md
+++ b/IPs/RSKIP298.md
@@ -8,7 +8,7 @@
 |**Purpose**    | Sca                           |
 |**Layer**      | Core                          |
 |**Complexity** | 2                             |
-|**Status**     | Draft                         |
+|**Status**     | Withdrawn                     |
 
 ## Abstract
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 293 |[Add method `getActivePowpegRedeemScript` to the Bridge contract and perform additional Flyover peg-in validations](IPs/RSKIP293.md)|  18-JAN-22 | JD | Usa, Sec | Core | 2 | Adopted |
 | 294 |[Limit the number of inputs to include in a migration transaction](IPs/RSKIP294.md)|  03-FEB-22 | MI | Sca, Sec | Core | 1 | Adopted |
 | 297 |[Increase max timestamp difference between btc and rsk blocks for Testnet](IPs/RSKIP297.md)|  13-APR-22 | VK | Usa | Core | 1 | Adopted |
-| 298 |[Bridge peg-out creation index](IPs/RSKIP298.md)|  18-APR-22 | JD | Sca | Core | 2 | Draft |
+| 298 |[Bridge peg-out creation index](IPs/RSKIP298.md)|  18-APR-22 | JD | Sca | Core | 2 | Withdrawn |
 | 305 |[Peg-out efficiency improvement (Segwit)](IPs/RSKIP305.md)|  01-JUN-22 | PDG, RVF & NV | Sca, Usa, Sec | Core | 2 | Adopted |
 | 326 |[Pegout events improvements](IPs/RSKIP326.md)|  21-JUNE-22 | KI & JT | Usa | Core | 1 | Adopted |
 | 336 |[Simple Parallelizable Semaphore](IPs/RSKIP336.md)|  11-JUL-22 | SDL | Sca | Core | 2 | Draft |


### PR DESCRIPTION
Sets the status to Withdrawn in the spec's header table and the README index (previously Draft in both). The proposed peg-out creation index ("pegoutCreationIndex-" + BTC tx hash → RSK tx hash) has no implementation trace in rskj and no follow-up since the 2022 proposal. This call is medium-confidence — Withdrawn was chosen over Deferred; if the idea is still alive, Deferred may be the better status.