### PR TITLE
RSKIP-378: set status to Accepted

### DIFF
--- a/IPs/RSKIP378.md
+++ b/IPs/RSKIP378.md
@@ -6,7 +6,7 @@ author: JZ
 purpose: Usa, Sec
 layer: Core
 complexity: 1
-status: Draft
+status: Accepted
 description: Adds a safety margin for the size (SegWit virtual size, following BIP 141) of the release transactions the Bridge creates (peg-outs and migrations).
 ---
 
@@ -18,7 +18,7 @@ description: Adds a safety margin for the size (SegWit virtual size, following B
 |**Purpose**    |Usa, Sec |
 |**Layer**      |Core |
 |**Complexity** |1 |
-|**Status**     |Draft |
+|**Status**     |Accepted |
 
 ## Abstract
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 375 |[Use the pegout creation transaction hash as the key in the map structure that stores the pegout transactions waiting for signatures](IPs/RSKIP375.md)| 30-MAY-23 | MI | Sca,Usa | Core | 1 | Adopted |
 | 376 |[Set version 2 to PowPeg migration transactions](IPs/RSKIP376.md)| 12-DEC-23 | MI | Usa | Core | 1 | Adopted |
 | 377 |[Store the last retired federation **standard** P2SH script](IPs/RSKIP377.md)| 17-MAY-23 | MI | Usa | Core | 1 | Adopted |
-| 378 |[Enforce release transaction size limit](IPs/RSKIP378.md)| 06-JUL-26 | JZ | Usa,Sec | Core | 1 | Draft |
+| 378 |[Enforce release transaction size limit](IPs/RSKIP378.md)| 06-JUL-26 | JZ | Usa,Sec | Core | 1 | Accepted |
 | 379 |[Bridge peg-out and migration transactions index](IPs/RSKIP379.md)| 12-DEC-23 | MI | Sca,Sec | Core | 2 | Adopted |
 | 383 |[Increase POWpeg activation age](IPs/RSKIP383.md)| 10-MAY-23 | JD | Fair | Core | 1 | Adopted |
 | 385 |[Bridge method `getEstimatedFeesForNextPegOutEvent` improvement](IPs/RSKIP385.md)| 12-MAY-23 | MI | Usa | Core | 1 | Adopted |


### PR DESCRIPTION
RSKIP-378 is implemented in rskj master (rsksmart/rskj#3602): [`ConsensusRule.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java) defines RSKIP378 and [`ReleaseTransactionBuilder.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/peg/ReleaseTransactionBuilder.java) enforces the vsize safety margin behind it. The code is not yet in a tagged release and the gating tbd1000 upgrade has no scheduled activation height, which matches the index's definition of Accepted (expected in the following reference client release). Aligns the status in the file frontmatter, the body table, and the README index (all read Draft).