### PR TITLE
RSKIP-529: set status to Accepted

### DIFF
--- a/IPs/RSKIP529.md
+++ b/IPs/RSKIP529.md
@@ -6,7 +6,7 @@ author: MI
 purpose: Sca
 layer: Core
 complexity: 1
-status: Draft
+status: Accepted
 description: 
 ---
 
@@ -18,7 +18,7 @@ description:
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |1 |
-|**Status**     |Draft |
+|**Status**     |Accepted |
 
 ## Abstract
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 516 |[Precompiled contracts for +/* on Secp256k1](IPs/RSKIP516.md)| 10-APR-2025 | SDL | Usa | Core | 2 | Adopted |
 | 517 |[Block time-centric difficulty adjustment with uncle threshold](IPs/RSKIP517.md)| 29-MAY-2025 | PDG | Sec,Sca | Core | 1 | Draft |
 | 518 |[Network Upgrade: Reed](IPs/RSKIP518.md)| 13-JUN-2025 | AE | Usa, Sca | Core | 3 | Adopted |
-| 529 |[New storage cells in Bridge native contract for base and super events info](IPs/RSKIP529.md)| 26-AUG-2025 | MI | Sca | Core | 1 | Draft |
+| 529 |[New storage cells in Bridge native contract for base and super events info](IPs/RSKIP529.md)| 26-AUG-2025 | MI | Sca | Core | 1 | Accepted |
 | 535 |[Add the `baseEvent` field to the Block header extension](IPs/RSKIP535.md)| 08-OCT-2025 | SDL | Sca | Core | 1 | Adopted (Testnet) |
 | 536 |[Additional methods for BlockHeader precompiled contract](IPs/RSKIP536.md)| 10-OCT-2025 | MI | Usa | Core | 1 | Adopted |
 | 540 |[Bridge method `getEstimatedFeesForNextPegOutEvent` improvements and new parameterized method](IPs/RSKIP540.md)| 04-DEC-2025 | MI | Usa | Core | 1 | Adopted |


### PR DESCRIPTION
Sets RSKIP-529's status to Accepted in the file frontmatter, the body header table and the README index (all read Draft). The proposal is implemented in rskj: [`ConsensusRule.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/org/ethereum/config/blockchain/upgrades/ConsensusRule.java) defines `RSKIP529`, gated behind the reed810 network upgrade in [`reference.conf`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/reference.conf).