### PR TITLE
RSKIP-144, RSKIP-351, RSKIP-502: set status to Adopted (Testnet)

### DIFF
--- a/IPs/RSKIP144.md
+++ b/IPs/RSKIP144.md
@@ -2,7 +2,7 @@
 rskip: 144
 title: Parallel Transaction Execution for Unitrie
 description: This RSKIP describes how miners partition transactions into disjoint sets in order to be safely parallelized, and how full nodes should process transactions.
-status: Accepted
+status: Adopted (Testnet)
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -19,7 +19,7 @@ created: 23-OCT-2019
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |3 |
-|**Status**     |Accepted |
+|**Status**     |Adopted (Testnet) |
 
 # Abstract
 

--- a/IPs/RSKIP351.md
+++ b/IPs/RSKIP351.md
@@ -1,7 +1,7 @@
 ---
 rskip: 351
 title: Miniheader - block header compression
-status: Draft
+status: Adopted (Testnet)
 purpose: Sca
 author: IO (ilan@iovlabs.org)
 layer: Core

--- a/IPs/RSKIP502.md
+++ b/IPs/RSKIP502.md
@@ -6,7 +6,7 @@ author: MI
 purpose: Sca
 layer: Core
 complexity: 1
-status: Accepted
+status: Adopted (Testnet)
 description: 
 ---
 
@@ -18,7 +18,7 @@ description:
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |1 |
-|**Status**     |Accepted |
+|**Status**     |Adopted (Testnet) |
 
 ## Abstract
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 139 |[Precompile to get transaction refunds](IPs/RSKIP139.md)| 10-SEP-19 | SDL       | Sca      | Core     | 1 | Draft   |
 | 140 |[EXTCODEHASH opcode](IPs/RSKIP140.md)| 04-SEP-19 | JL | Usa | Core | 2 | Adopted |
 | 141 |[Network Upgrade: Papyrus](IPs/RSKIP141.md)| 27-SEP-19 | AE | Sca,Usa,Sec | Core | 2 | Adopted |
-| 144 |[Parallel Transaction Execution for Unitrie](IPs/RSKIP144.md)| 13-OCT-19 | SDL | Sca | Core | 3 | Accepted |
+| 144 |[Parallel Transaction Execution for Unitrie](IPs/RSKIP144.md)| 13-OCT-19 | SDL | Sca | Core | 3 | Adopted (Testnet) |
 | 145 |[Struct Transaction Format](IPs/RSKIP145.md)|  20-FEB-17 | SDL | Sca | Core | 2 | Draft |
 | 146 |[Encode bridge events in Solidity format](IPs/RSKIP146.md)|  25-OCT-19 | MI & JD | Usa | Core | 2 | Adopted |
 | 148 |[ERC1820 Pseudo-introspection Registry Contract](IPs/RSKIP148.md)|  6-NOV-19 | PMP | Usa | DApp | 1 | Adopted |
@@ -212,7 +212,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 305 |[Peg-out efficiency improvement (Segwit)](IPs/RSKIP305.md)|  01-JUN-22 | PDG, RVF & NV | Sca, Usa, Sec | Core | 2 | Adopted |
 | 326 |[Pegout events improvements](IPs/RSKIP326.md)|  21-JUNE-22 | KI & JT | Usa | Core | 1 | Adopted |
 | 336 |[Simple Parallelizable Semaphore](IPs/RSKIP336.md)|  11-JUL-22 | SDL | Sca | Core | 2 | Draft |
-| 351 |[Miniheader: block header compression](IPs/RSKIP351.md)|  12-SEP-22 | IO | Sca | Core | 1 | Draft |
+| 351 |[Miniheader - block header compression](IPs/RSKIP351.md)|  12-SEP-22 | IO | Sca | Core | 1 | Adopted (Testnet) |
 | 353 |[Align RSK P2SH redeem script with Bitcoin Core standard transactions checks](IPs/RSKIP353.md)|  24-OCT-22 | MI,AE | Usa,Sec | Core | 2 | Adopted |
 | 357 |[Adjust the number of block confirmations for a PowPeg migration period](IPs/RSKIP357.md)|  25-OCT-22 | AE | Usa,Sec | Core | 1 | Adopted |
 | 358 |[Network Upgrade (patch): Hop 4.0.1](IPs/RSKIP358.md)| 26-OCT-22 | AE | Usa,Sec | Core | 2 | Adopted |
@@ -247,7 +247,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 459 |[Mark rejected peg-ins as processed](IPs/RSKIP459.md)| 10-DEC-24 | MI | Usa | Core | 1 | Adopted |
 | 460 |[Ignore non-standard outputs when searching for the witness commitment hash](IPs/RSKIP460.md)| 12-DEC-24 | MI | Usa,Sec | Core | 1 | Adopted |
 | 491 |[Reduce target difficulty to lower average block time to 10s](IPs/RSKIP491.md)| 27-FEB-2025 | PDG | Usa | Core | 1 | Draft |
-| 502 |[PowPeg and Union Bridge integration](IPs/RSKIP502.md)| 19-MAR-2025 | MI | Sca | Core | 1 | Accepted |
+| 502 |[PowPeg and Union Bridge integration](IPs/RSKIP502.md)| 19-MAR-2025 | MI | Sca | Core | 1 | Adopted (Testnet) |
 | 516 |[Precompiled contracts for +/* on Secp256k1](IPs/RSKIP516.md)| 10-APR-2025 | SDL | Usa | Core | 2 | Adopted |
 | 517 |[Block time-centric difficulty adjustment with uncle threshold](IPs/RSKIP517.md)| 29-MAY-2025 | PDG | Sec,Sca | Core | 1 | Draft |
 | 518 |[Network Upgrade: Reed](IPs/RSKIP518.md)| 13-JUN-2025 | AE | Usa, Sca | Core | 3 | Adopted |


### PR DESCRIPTION
Sets all three to **Adopted (Testnet)** — in each spec's frontmatter, its body header table (144 and 502; 351 has none), and the README index. Also aligns RSKIP-351's index title with the spec (`Miniheader - block header compression`).

Configuration check in rskj: [`reference.conf`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/reference.conf) maps `rskip144`, `rskip351` and `rskip502` to the **reed810** network upgrade; [`testnet.conf`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/config/testnet.conf) activates reed810 at 7,139,600 (passed — testnet is beyond 7.9M), while [`main.conf`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/resources/config/main.conf) keeps `reed810 = -1` with no per-rule override for any of the three (unlike `rskip536`, individually rescheduled at the Vetiver height). Same treatment as RSKIP-529 (#641); RSKIP-535 already carries this status.