### PR TITLE
RSKIP-24: set status to Superseded (by RSKIP107)

### DIFF
--- a/IPs/RSKIP107.md
+++ b/IPs/RSKIP107.md
@@ -3,6 +3,7 @@ rskip: 107
 title: Smaller Unitrie Nodes for Higher Scalability
 description: 
 status: Draft
+replaces: 24
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core

--- a/IPs/RSKIP24.md
+++ b/IPs/RSKIP24.md
@@ -2,7 +2,8 @@
 rskip: 24
 title: New Binary Trie
 description: 
-status: Adopted
+status: Superseded
+superseded-by: 107
 purpose: Sca
 author: SDL (@sergiodemianlerner)
 layer: Core
@@ -20,13 +21,16 @@ created: 2016-12-23
 |**Purpose**    |Sca |
 |**Layer**      |Core |
 |**Complexity** |3 |
-|**Status**     |Adopted |
+|**Status**     |Superseded |
+|**Superseded-By** |[RSKIP107](https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP107.md) |
 
 # **Abstract**
 
 The current RSK trie (inherited from Ethereum) has several problems, both in its design and in its implementation. This RSKIP attempts to current these problems and also improve the performance of the node by adding lazy evaluation of hashes in the trie, and providing an uniform cache structure.
 
 NOTE: Parts of this document have been deprecated: the Clone, Commit, Rollback (CCR) block-verification method described here is not compatible with parallel transaction verification. The node format of the adopted binary trie (Unitrie) is specified in [RSKIP107](https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP107.md).
+
+NOTE: This RSKIP has been superseded by [RSKIP107](https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP107.md), which specifies the Unitrie node format in production today.
 
 
 # **Motivation**

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can find an easily browseable version of this information [here](https://ips
 | 21       | [Efficient Persistent Storage Rent](IPs/RSKIP21.md)                              | 02-DIC-16 | SDL       | Sca      | Core     | 2 | Draft*   |
 | 22       | [Commit to number of Merkle tree elements](IPs/RSKIP22.md)                       | 04-DIC-16 | SDL       | Sca      | Core     | 1 | Draft    |
 | 23       | [Onchain PoUBS](IPs/RSKIP23.md)                                                  | 05-DIC-16 | SDL       | Sca      | Core     | 3 | Draft*   |
-| 24       | [New Binary Trie](IPs/RSKIP24.md)                                                | 23-DIC-16 | SDL       | Sca      | Core     | 3 | Adopted  |
+| 24       | [New Binary Trie](IPs/RSKIP24.md)                                                | 23-DIC-16 | SDL       | Sca      | Core     | 3 | Superseded  |
 | 25       | [Memory caches](IPs/RSKIP25.md)                                                  | 27-DIC-16 | SDL       | Sca      | Core     | 2 | Draft    |
 | 26       | [DUPN and SWAPN opcodes](IPs/RSKIP26.md)                                         | 27-DIC-16 | SDL       | Sca      | Core     | 1 | Adopted  |
 | 27       | [Highly Efficient Storage Rent](IPs/RSKIP27.md)                                  | 29-DIC-16 | SDL       | Sca/Fair | Core     | 2 | Draft    |


### PR DESCRIPTION
Sets RSKIP-24's status to **Superseded** and names its successor: [RSKIP107](https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP107.md), which specifies the Unitrie node format rskj ships today ([`Trie.java`](https://github.com/rsksmart/rskj/blob/master/rskj-core/src/main/java/co/rsk/trie/Trie.java) implements RSKIP107's versioned node serialization, not the format this document describes).

Per [RSKIP0's status vocabulary](https://github.com/rsksmart/RSKIPs/blob/master/IPs/RSKIP0.md), *Superseded* is the status for an RSKIP rendered obsolete by a later document, recorded with the `Superseded-By` header. RSKIP-24 is the historical fit: its binary trie was adopted and ran in production, and was then replaced by RSKIP107's node format — the document itself already carries a deprecation note (clarified in #652) conceding the CCR block-verification method is not what runs.

Changes, documentation-only:
- frontmatter: `status: Superseded`, plus the `superseded-by: 107` header
- body status table: `Superseded`, plus a `Superseded-By` row linking RSKIP107
- Abstract: a note naming RSKIP107 as the successor
- README index: the RSKIP-24 row now reads `Superseded` (the term is already defined in the README's status list)

Part of the Historical RSKIPs review.
